### PR TITLE
Add fetch polyfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # proto
+
 Shared Protocol Buffers and their associated generated code
+
+## Working on this repo
+
+Before committing any changes to this repo, you will want to run `npm i` at least once. This will install the Husky precommit hooks to your machine.
+
+Go code will be regenerated based on the `.proto` files on each commit and does not need to be done manually.
+
+Commit messages must be in the [Angular Commit Message Convention](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,12 @@
       "name": "@xmtp/proto",
       "version": "0.0.0-development",
       "license": "MIT",
+      "dependencies": {
+        "undici": "^5.8.1"
+      },
       "devDependencies": {
         "@commitlint/config-conventional": "^17.0.3",
+        "@types/node": "^18.6.4",
         "husky": "^8.0.0",
         "semantic-release": "^19.0.3"
       }
@@ -457,6 +461,12 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
       "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "18.6.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.4.tgz",
+      "integrity": "sha512-I4BD3L+6AWiUobfxZ49DlU43gtI+FTHSv9pE2Zekg6KjMpre4ByusaljW3vYSLJrvQ1ck1hUaeVu8HVlY3vzHg==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -5745,6 +5755,14 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/undici": {
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.8.1.tgz",
+      "integrity": "sha512-iDRmWX4Zar/4A/t+1LrKQRm102zw2l9Wgat3LtTlTn8ykvMZmAmpq9tjyHEigx18FsY7IfATvyN3xSw9BDz0eA==",
+      "engines": {
+        "node": ">=12.18"
+      }
+    },
     "node_modules/unique-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
@@ -6262,6 +6280,12 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
       "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "18.6.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.4.tgz",
+      "integrity": "sha512-I4BD3L+6AWiUobfxZ49DlU43gtI+FTHSv9pE2Zekg6KjMpre4ByusaljW3vYSLJrvQ1ck1hUaeVu8HVlY3vzHg==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -10099,6 +10123,11 @@
       "integrity": "sha512-uVbFqx9vvLhQg0iBaau9Z75AxWJ8tqM9AV890dIZCLApF4rTcyHwmAvLeEdYRs+BzYWu8Iw81F79ah0EfTXbaw==",
       "dev": true,
       "optional": true
+    },
+    "undici": {
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.8.1.tgz",
+      "integrity": "sha512-iDRmWX4Zar/4A/t+1LrKQRm102zw2l9Wgat3LtTlTn8ykvMZmAmpq9tjyHEigx18FsY7IfATvyN3xSw9BDz0eA=="
     },
     "unique-string": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -2,12 +2,13 @@
   "name": "@xmtp/proto",
   "version": "0.0.0-development",
   "description": "Protobuf client and generated classes for GRPC API",
-  "main": "./ts/dist/cjs/index.js",
-  "module": "./ts/dist/esm/index.js",
+  "main": "./ts/dist/cjs/node.js",
+  "module": "./ts/dist/esm/node.js",
   "types": "./ts/dist/types/index.d.ts",
+  "browser": "./ts/dist/esm/index.js",
   "exports": {
     ".": {
-      "types": "./ts/types/cjs/index.d.ts",
+      "types": "./ts/types/types/index.d.ts",
       "import": "./ts/dist/esm/index.js",
       "require": "./ts/dist/cjs/index.js"
     }
@@ -59,7 +60,11 @@
   "homepage": "https://github.com/xmtp/proto#readme",
   "devDependencies": {
     "@commitlint/config-conventional": "^17.0.3",
+    "@types/node": "^18.6.4",
     "husky": "^8.0.0",
     "semantic-release": "^19.0.3"
+  },
+  "dependencies": {
+    "undici": "^5.8.1"
   }
 }

--- a/ts/node.ts
+++ b/ts/node.ts
@@ -1,0 +1,9 @@
+if (typeof fetch === "undefined") {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { fetch, Request, Response, Headers } = require("undici");
+  global.fetch = fetch;
+  global.Request = Request;
+  global.Response = Response;
+  global.Headers = Headers;
+}
+export * from "./index";


### PR DESCRIPTION
## Summary
- Adds a polyfill for the `fetch` API to this repo.
- Updates the README to explain the precommit hooks and how to setup development

## Notes
- All of the generated proto code relies on the Fetch API, which is standard in browsers but not in Node. This PR creates a fetch polyfill using [Undici](https://undici.nodejs.org/#/), which adheres closer to the fetch WHATWG standard than other fetch polyfills you can find on NPM. I tried the more standard fetch polyfill (cross-fetch), but it conflicts with @stardazed/streams-polyfill - which we use for message compression - and causes the application to crash on startup. This appears to be because of the non-standard body types [explained here](https://github.com/node-fetch/node-fetch/blob/main/docs/v3-LIMITS.md). Given the focus on standards-compliance, and the support of Node.js core (it is in the process of merging into Node.js itself), it feels like a better choice than cross-fetch even if we have to do the polyfilling ourselves.
- We use the `browser` field of the package.json to not include the polyfill module in browser bundles made with Rollup or Webpack.