### PR TITLE
Force long for TS protos

### DIFF
--- a/dev/ts/generate
+++ b/dev/ts/generate
@@ -17,6 +17,7 @@ docker run --rm -i -v${PWD}:/code xmtp/protoc \
   -I=./proto \
   --plugin=/usr/local/lib/node_modules/ts-proto/protoc-gen-ts_proto \
   --experimental_allow_proto3_optional \
+  --ts_proto_opt=forceLong=long \
   --ts_proto_out=./ts \
   --ts_proto_opt=fileSuffix=.pb \
   --ts_proto_opt=esModuleInterop=true \


### PR DESCRIPTION
## Summary
When dealing with the nanosecond timestamps for `authn` I realized that the way we have been generating protos this whole time has a key flaw. We have been using the default option for `ts-proto`, which converts `uint64` numbers to Javascript numbers at runtime. The problem is that Javascript numbers have a maximum value of `2^53`. This hasn't been a problem until now because all of the datestamps in our message protos are millisecond dates that are under the limit. But for the Token, we would like to use nanosecond dates which are above the limit. Switching to always use `Long` values will allow us to use the full 64 bits of a `uint64`.

This changes the generator to use the Long data type for all `uint64` values. It will require a corresponding change to the `js-sdk`. There are no changes to the wire format with this configuration change, or our public APIs for the Client SDK. Only to the generated code.