### PR TITLE
Polyfill all stream classes from node builtins

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,13 +6,6 @@
   "module": "./ts/dist/esm/node.js",
   "types": "./ts/dist/types/index.d.ts",
   "browser": "./ts/dist/esm/index.js",
-  "exports": {
-    ".": {
-      "types": "./ts/types/types/index.d.ts",
-      "import": "./ts/dist/esm/index.js",
-      "require": "./ts/dist/cjs/index.js"
-    }
-  },
   "scripts": {
     "build": "npm run clean && npm run build:cjs && npm run build:esm && npm run build:types",
     "build:cjs": "./dev/ts/clean cjs && tsc -p ./ts/tsconfig.cjs.json",

--- a/ts/node.ts
+++ b/ts/node.ts
@@ -1,9 +1,44 @@
-if (typeof fetch === "undefined") {
+function getGlobal(): any | undefined {
+  if (typeof globalThis !== "undefined") {
+    return globalThis;
+  }
+  if (typeof self !== "undefined") {
+    return self;
+  }
+  if (typeof window !== "undefined") {
+    return window;
+  }
+  if (typeof global !== "undefined") {
+    return global;
+  }
+  return undefined;
+}
+
+const ctx = getGlobal();
+
+if (typeof ctx.fetch === "undefined") {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const { fetch, Request, Response, Headers } = require("undici");
-  global.fetch = fetch;
-  global.Request = Request;
-  global.Response = Response;
-  global.Headers = Headers;
+  ctx.fetch = fetch;
+  ctx.Request = Request;
+  ctx.Response = Response;
+  ctx.Headers = Headers;
 }
+
+const streamClasses = [
+  "TextDecoderStream",
+  "TextEncoderStream",
+  "TransformStream",
+  "ReadableStream",
+  "WritableStream",
+  "ByteLengthQueuingStrategy",
+  "CountQueuingStrategy",
+];
+
+for (const clsName of streamClasses) {
+  if (typeof ctx[clsName] === "undefined") {
+    ctx[clsName] = require("stream/web")[clsName];
+  }
+}
+
 export * from "./index";


### PR DESCRIPTION
## Summary
I've been struggling for the past week to get the test/node environment as close as possible to the browser environment for our streaming responses. The main issue is caused by the fact that `xmtp-js` uses the `@stardazed/streams-polyfill` to give us `CompressionStream` and `DecompressionStream` classes in node/test environments. In addition to those streams that are strictly necessary, the polyfill also creates globals for `ReadableStream`, `WriteableStream`, and many others.

These polyfills differ from the browser behavior when streams are aborted, and cause error events to bubble up in a way that cannot be caught with a try/catch. The polyfill library is not very actively maintained, or widely used, and I would like to get away from it altogether.

This change includes polyfills for all of the stream types using native Node.js [WHATWG Streams](https://github.com/whatwg/streams) compatible APIs, which have been available in Node.js since version 16.x. Node.js 16.x does not include `CompressionStream` and `DecompressionStream` classes, although Node 18 does, so until Node 18 reaches LTS and is widely supported in serverless environments we will still have to use `@stardazed/streams-polyfill` for those particular classes. 

This does mean that `@xmtp/proto` needs to be imported in the calling app _before_ `@stardazed/streams-polyfill` or the polyfill will create the globals first and these changes will not be triggered.

@elisealix22 for React Native this solution will not work as it does not have access to the `web/streams` builtin node module. To go back to how things worked yesterday you just need to import `@stardazed/streams-polyfill` before importing the `@xmtp/xmtp-js` SDK and everything should work. Lmk if you have any problems with this.

## Alternatives
While `@stardazed` does offer direct classes for just `CompressionStream` and `DecompressionStream` as a separate package, importing that package fails as it points to an ESM module for `zlib` which fails to compile because of the use of the `export` keyword. An alternative solution would be to pave over that with some overrides in our jest config and web pack config, but I don't know how to make that work properly in a Node.js environment without some real dirty hackery.