### PR TITLE
fix: bump go module version to v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/xmtp/proto
+module github.com/xmtp/proto/v3
 
 go 1.18
 


### PR DESCRIPTION
This is an attempt to deal with https://github.com/xmtp/xmtp-node-go/pull/185#discussion_r1022073608, or

> xmtp-node-go % go get github.com/xmtp/proto@v3.9.0
go: github.com/xmtp/proto@v3.9.0: invalid version: module contains a go.mod file, so module path must match major version ("github.com/xmtp/proto/v3")

It's not clear to me if it's enough to declare the v3 suffix in the go.mod file or whether we have to also reflect that in the directory structure (in that case I assume we'd have to add something like `go/v3/go.mod` and symlink the source directories in there or something).

I tried to play with `github.com/xmtp/proto v3.9.0+incompatible` on the node side but that didn't seem to do the trick. 🤷 