### PR TITLE
Lock typescript type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "@commitlint/config-conventional": "^17.0.3",
         "@types/node": "^18.6.4",
         "husky": "^8.0.0",
-        "semantic-release": "^19.0.3"
+        "semantic-release": "^19.0.3",
+        "typescript": "^4.6.4"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -5831,6 +5832,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/typescript": {
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/uglify-js": {
       "version": "3.16.3",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.3.tgz",
@@ -10287,6 +10301,12 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
       "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+      "dev": true
+    },
+    "typescript": {
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "pretest": "npm run build",
     "prepublish": "npm run build",
     "semantic-release": "semantic-release",
+    "typescript": "^4.6.4",
     "test": "node ./ts/dist/cjs/index.js"
   },
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "@commitlint/config-conventional": "^17.0.3",
     "@types/node": "^18.6.4",
     "husky": "^8.0.0",
-    "semantic-release": "^19.0.3"
+    "semantic-release": "^19.0.3",
+    "typescript": "^4.6.4"
   },
   "dependencies": {
     "long": "^5.2.0",


### PR DESCRIPTION
Fixed here: https://github.com/xmtp/proto/pull/30#discussion_r1033798195

Lets lock the typescript type so the tests don't fail