### PR TITLE
[Kotlin] Fix shallow repo fetch not getting tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,8 @@ jobs:
     steps:
     - name: Checkout project sources
       uses: actions/checkout@v3
-    - run: git fetch --prune --unshallow --tags
+      with:
+        fetch-depth: 0
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2
     - name: Validate Gradle Wrapper

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,7 @@ jobs:
     steps:
     - name: Checkout project sources
       uses: actions/checkout@v3
+    - run: git fetch --prune --unshallow
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2
     - name: Validate Gradle Wrapper

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
     steps:
     - name: Checkout project sources
       uses: actions/checkout@v3
-    - run: git fetch --prune --unshallow
+    - run: git fetch --prune --unshallow --tags
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2
     - name: Validate Gradle Wrapper


### PR DESCRIPTION
3rd times a charm. When I ran the command locally it worked fine but in the github action it failed with 
```
Run TAG=`echo $(git describe --tags --abbrev=0)`
fatal: No names found, cannot describe anything.
```
From this [stackoverflow](https://stackoverflow.com/questions/4916492/git-describe-fails-with-fatal-no-names-found-cannot-describe-anything) I discovered that the github action was making a shallow clone of the repo that did not include the tag information. This should fix that. 🤞 
