### PR TITLE
OSSRH Kotlin Package Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,4 +63,6 @@ jobs:
         RELEASE_VERSION: ${{ env.GIT_TAG }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GITHUB_ACTOR: ${{ secrets.GITHUB_ACTOR }}
+        MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+        MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
       run: ./gradlew publish

--- a/kotlin/build.gradle
+++ b/kotlin/build.gradle
@@ -61,6 +61,20 @@ sourceSets {
     }
 }
 
+task sourcesJar(type: Jar) {
+    classifier = "sources"
+    from sourceSets.main.allJava
+}
+
+task javadocJar(type: Jar) {
+    classifier = "javadoc"
+    from javadoc.destinationDir
+}
+
+artifacts {
+    archives javadocJar, sourcesJar
+}
+
 publishing {
     publications {
         mavenKotlin(MavenPublication) {
@@ -68,11 +82,48 @@ publishing {
             artifactId = "kotlin"
             version = System.getenv("RELEASE_VERSION")
             from components.kotlin
+            artifact sourcesJar
+            artifact javadocJar
+
+            pom {
+                name = "kotlin"
+                description = "XMTP Proto Kotlin Library"
+                url = "https://github.com/xmtp/proto"
+                packaging = "jar"
+
+                licenses {
+                    license {
+                        name = "MIT License"
+                        url = "https://github.com/xmtp/proto/blob/main/LICENSE"
+                    }
+                }
+                developers {
+                    developer {
+                        id = "xmtp"
+                        name = "xmtp"
+                        email = "naomi@xmtp.com"
+                    }
+                }
+                scm {
+                    connection = "https://github.com/xmtp/proto.git"
+                    developerConnection =  "https://github.com/xmtp/proto.git"
+                    url = "https://github.com/xmtp/proto/tree/main"
+                }
+            }
         }
     }
+    
      repositories {
         maven {
-            name = "XMTPKotlinPackage"
+            name = "XMTPKotlinOSSPackage"
+            url = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+            credentials {
+                username = System.getenv("MAVEN_USERNAME")
+                password = System.getenv("MAVEN_PASSWORD")
+            }
+        }
+        maven {
+            name = "XMTPKotlinGitHubPackage"
             url = uri("https://maven.pkg.github.com/xmtp/proto")
             credentials {
                 username = System.getenv("GITHUB_ACTOR")

--- a/kotlin/build.gradle
+++ b/kotlin/build.gradle
@@ -116,7 +116,7 @@ publishing {
      repositories {
         maven {
             name = "XMTPKotlinOSSPackage"
-            url = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+            url = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
             credentials {
                 username = System.getenv("MAVEN_USERNAME")
                 password = System.getenv("MAVEN_PASSWORD")

--- a/kotlin/build.gradle
+++ b/kotlin/build.gradle
@@ -63,10 +63,10 @@ sourceSets {
 
 task sourcesJar(type: Jar) {
     classifier = "sources"
-    from sourceSets.main.allJava
+    from sourceSets.main.java.srcDirs
 }
 
-task javadocJar(type: Jar) {
+task javadocJar(type: Jar, dependsOn: javadoc) {
     classifier = "javadoc"
     from javadoc.destinationDir
 }


### PR DESCRIPTION
Following the [Open Source Repository Hosting documention](https://central.sonatype.org/publish/requirements) to add additional information to the package release. 
Kotlin will now be released as a GitHub Package and a Maven Central Repository Package to allow easier access from the consuming integrations. In the future we may be able to delete the releasing to GitHub Packages.