### PR TITLE
fix: sign kotlin gradle release

### DIFF
--- a/kotlin/build.gradle
+++ b/kotlin/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'org.jetbrains.kotlin.jvm' version '1.7.10'
     id 'java-library'
     id 'maven-publish'
+    id 'signing'
     id 'com.google.protobuf' version '0.9.1'
 }
 
@@ -131,6 +132,10 @@ publishing {
             }
         }
     }
+}
+
+signing {
+    sign publishing.publications.mavenKotlin
 }
 
 tasks.named('test') {


### PR DESCRIPTION
Per this documentation https://central.sonatype.org/publish/publish-gradle/

> In order to deploy your components to OSSRH with Gradle, you have to meet the [requirements](https://central.sonatype.org/publish/requirements/) for your metadata in the pom.xml as well as supply the required, signed components.

I think I was missing the signed components. 