### PR TITLE
fix: Update group id match OSSHR

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'io.github.gradle-nexus.publish-plugin' version "1.2.0"
 }
 
-group = "org.xmtp.proto.kotlin"
+group = "org.xmtp"
 version = System.getenv("RELEASE_VERSION")
 
 nexusPublishing {

--- a/kotlin/build.gradle
+++ b/kotlin/build.gradle
@@ -79,6 +79,9 @@ artifacts {
 publishing {
     publications {
         mavenKotlin(MavenPublication) {
+            groupId = "org.xmtp"
+            artifactId = "proto-kotlin"
+            version = System.getenv("RELEASE_VERSION")
             from components.kotlin
             artifact sourcesJar
             artifact javadocJar


### PR DESCRIPTION
Per this conversation https://issues.sonatype.org/browse/OSSRH-89132?page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel&focusedId=1244733#comment-1244733

> Profile target mismatch 

Means that the groupID was not lining up correctly this aims to correct that.