### PR TITLE
Add TopicMap data structure

### DIFF
--- a/proto/keystore_api/v1/keystore.proto
+++ b/proto/keystore_api/v1/keystore.proto
@@ -154,3 +154,8 @@ message SaveInvitesResponse {
 
     repeated Response responses = 1;
 }
+
+// A mapping of topics to their decrypted invitations
+message TopicMap {
+    map<string, xmtp.message_contents.InvitationV1> topics = 1;
+}


### PR DESCRIPTION
## Summary

For Keystore Conversation V2 serialization I need a new proto message to make it easy to store all of the conversations in a single byte array.

All this does is create a new message that stores a mapping of topics to `InvitationV1`. This way all conversations can be stored in a single key in the KV map.

## Notes

Not too worried about forward compatibility with new invitation types, since I think the default behaviour for the persistence layer will be to just use a new key when major changes are introduced.