### PR TITLE
Add peer_address

### DIFF
--- a/proto/keystore_api/v1/keystore.proto
+++ b/proto/keystore_api/v1/keystore.proto
@@ -23,8 +23,9 @@ message KeystoreError {
 // A light pointer for a conversation that contains no decryption keys
 message ConversationReference {
     string topic = 1;
-    uint64 created_ns = 2;
-    xmtp.message_contents.InvitationV1.Context context = 3;
+    string peer_address = 2;
+    uint64 created_ns = 3;
+    xmtp.message_contents.InvitationV1.Context context = 4;
 }
 
 // Decrypt a batch of messages using X3DH key agreement
@@ -160,7 +161,8 @@ message TopicMap {
     // TopicData wraps the invitation and the timestamp it was created
     message TopicData {
         uint64 created_ns = 1;
-        xmtp.message_contents.InvitationV1 invitation = 2;
+        string peer_address = 2;
+        xmtp.message_contents.InvitationV1 invitation = 3;
     }
     map<string, TopicData> topics = 1;
 }


### PR DESCRIPTION
## Summary

Adds a `peer_address` field to simplify management of conversations. This allows the `ConversationReference` to be free-standing, and all the SDK needs to work with a conversation.

## Notes
Because these protos are not currently persisted anywhere, I can add new fields out of order without worrying about breaking anything.