### PR TITLE
fix: dynamically update the pubspec version to match the release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,8 +39,16 @@ jobs:
       - run: dev/dart/generate
       - run: dart test
         working-directory: ./dart
-      - run: dev/dart/prepublish
+      - name: Set Tag
+        run: |
+          TAG=`echo $(git describe --tags --abbrev=0)`
+          echo "GIT_TAG=${TAG#v}" >> $GITHUB_ENV
+      - name: Prepublish
+        env:
+          RELEASE_VERSION: ${{ env.GIT_TAG }}
+        run: dev/dart/prepublish
       - run: dart pub publish --force
+        working-directory: ./dart
   kotlin:
     if: ${{ github.ref_name == 'main' }}
     name: Release (Kotlin)

--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -1,6 +1,7 @@
 name: xmtp_proto
 description: Protobuf client and generated classes for GRPC API
-version: 0.0.0-development
+# Version replaced at runtime in dev/dart/prepublish
+version: 0.0.0
 repository: 'https://github.com/xmtp/proto'
 
 environment:

--- a/dev/dart/prepublish
+++ b/dev/dart/prepublish
@@ -12,3 +12,7 @@ cp ./README.md ./dart/README.md
 cp ./LICENSE ./dart/LICENSE
 # TODO: include changelog if/when we have one
 #cp ./CHANGELOG.md ./dart/CHANGELOG.md
+
+# Update pubspec.yaml version to use tagged version
+# See https://dart.dev/tools/pub/automated-publishing#triggering-automated-publishing-from-github-actions
+sed "s/version: 0.0.0/version: $RELEASE_VERSION/" ./dart/pubspec.yaml


### PR DESCRIPTION
The last dart proto publish failed because the pubspec file couldn't be found. It also wasn't using the correct version. This PR attempts to update the version to the latest tag during the GitHub `release` Action to fix the publish.

Ref: https://dart.dev/tools/pub/automated-publishing#triggering-automated-publishing-from-github-actions
Failed Action: https://github.com/xmtp/proto/actions/runs/4535405973/jobs/7990814265#step:8:9