### PR TITLE
fix: checkout depth is needed for setting dart tag version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,10 @@ jobs:
       id-token: write # This is required for authentication using GitHub OIDC
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout project sources
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - uses: dart-lang/setup-dart@v1.3
       - run: dart pub get
         working-directory: ./dart


### PR DESCRIPTION
The last Dart publish used the incorrect version because the tag wasn't set correctly. This PR fixes the checkout depth in order to set the tag version.

<img width="614" alt="Screenshot 2023-03-27 at 3 48 57 PM" src="https://user-images.githubusercontent.com/556051/228052200-f8005413-fa81-43cc-8a04-c35d2db1514a.png">
