### PR TITLE
Add referencing_message_id to EncodedContent

### DIFF
--- a/proto/message_contents/content.proto
+++ b/proto/message_contents/content.proto
@@ -41,6 +41,8 @@ message EncodedContent {
     optional Compression compression = 5;
     // encoded content itself
     bytes content = 4;
+    // optional ID of a message that this message is referencing
+    optional string referencing_message_id = 6;
 }
 
 // SignedContent attaches a signature to EncodedContent.


### PR DESCRIPTION
There have recently been a couple XIPs opened for content types that need to reference other messages:

- [Replies](https://github.com/xmtp/XIPs/pull/22) need to reference the message they're replying to
- [Reactions](https://github.com/xmtp/XIPs/pull/23) need to reference the message they're reacting to

This PR adds a an optional new field to `EncodedContent` named `referencing_message_id`. The value of this field should be the `id` of a `DecodedMessage`.

To implement message replies, clients can just send a new message with whatever content types they support and include the original message's ID as the `referencing_message_id`.

To implement message reactions, we could add a new content type that can focus on the actual behavior of reactions, including things like `added`, `removed` etc, leaving the relationship between the content and the original message to this new field.

I could also see a future where we could use `referencing_message_id` to implement message editing and deletion or starring/pinning.