### PR TITLE
fix: listen for tags to publish dart

### DIFF
--- a/.github/workflows/publish-dart.yml
+++ b/.github/workflows/publish-dart.yml
@@ -1,0 +1,39 @@
+# .github/workflows/publish.yml
+name: Publish to pub.dev
+on:
+  push:
+    tags:
+    # must align with the tag-pattern configured on pub.dev
+    - 'v[0-9]+.[0-9]+.[0-9]+*' # tag-pattern on pub.dev: 'v'
+jobs:
+  dart:
+    # https://dart.dev/tools/pub/automated-publishing
+    name: Release (dart)
+    permissions:
+      id-token: write # This is required for requesting the JWT
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout project sources
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      # Setup Dart SDK with JWT token https://github.com/dart-lang/setup-dart/blob/77b84bec90e9a0d07f68a3cedd3651ba9e606a12/.github/workflows/publish.yml#L33
+      - uses: dart-lang/setup-dart@a57a6c04cf7d4840e88432aad6281d1e125f0d46
+      - run: dart pub get
+        working-directory: ./dart
+      - run: dev/dart/generate
+      - run: dart test
+        working-directory: ./dart
+      - name: Set Tag
+        run: |
+          TAG=`echo $(git describe --tags --abbrev=0)`
+          echo "GIT_TAG=${TAG#v}" >> $GITHUB_ENV
+      - name: Prepublish
+        env:
+          RELEASE_VERSION: ${{ env.GIT_TAG }}
+        run: dev/dart/prepublish
+      - name: Verify pubspec
+        run: cat ./dart/pubspec.yaml
+      - name: Publish
+        run: dart pub publish --force
+        working-directory: ./dart

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,38 +24,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm run semantic-release
-  dart:
-    if: ${{ github.ref_name == 'main' }}
-    # https://dart.dev/tools/pub/automated-publishing
-    name: Release (dart)
-    permissions:
-      id-token: write # This is required for requesting the JWT
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout project sources
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      # Setup Dart SDK with JWT token https://github.com/dart-lang/setup-dart/blob/77b84bec90e9a0d07f68a3cedd3651ba9e606a12/.github/workflows/publish.yml#L33
-      - uses: dart-lang/setup-dart@a57a6c04cf7d4840e88432aad6281d1e125f0d46
-      - run: dart pub get
-        working-directory: ./dart
-      - run: dev/dart/generate
-      - run: dart test
-        working-directory: ./dart
-      - name: Set Tag
-        run: |
-          TAG=`echo $(git describe --tags --abbrev=0)`
-          echo "GIT_TAG=${TAG#v}" >> $GITHUB_ENV
-      - name: Prepublish
-        env:
-          RELEASE_VERSION: ${{ env.GIT_TAG }}
-        run: dev/dart/prepublish
-      - name: Verify pubspec
-        run: cat ./dart/pubspec.yaml
-      - name: Publish
-        run: dart pub publish --force
-        working-directory: ./dart
   kotlin:
     if: ${{ github.ref_name == 'main' }}
     name: Release (Kotlin)


### PR DESCRIPTION
Unfortunately, dart requires a tag to kick off the GitHub Action in order to publish the release. The last build failed because it was triggered by a push to `main` even though it had the correct tag and version in the `pubspec.yaml`: https://github.com/xmtp/proto/actions/runs/4544664990/jobs/8010997528#step:10:81

This is an attempt to listen for tags created by the JS release process. If the creation of the tag as a part of the JS release flow does not trigger this action, then I believe we will have to manually push a specific tag like `vX.Y.Z-dart` to trigger a publish.
