### PR TITLE
fix: use current ref version for dart release

### DIFF
--- a/.github/workflows/publish-dart.yml
+++ b/.github/workflows/publish-dart.yml
@@ -13,10 +13,7 @@ jobs:
       id-token: write # This is required for requesting the JWT
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout project sources
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@v3
       # Setup Dart SDK with JWT token https://github.com/dart-lang/setup-dart/blob/77b84bec90e9a0d07f68a3cedd3651ba9e606a12/.github/workflows/publish.yml#L33
       - uses: dart-lang/setup-dart@a57a6c04cf7d4840e88432aad6281d1e125f0d46
       - run: dart pub get
@@ -25,9 +22,7 @@ jobs:
       - run: dart test
         working-directory: ./dart
       - name: Set Tag
-        run: |
-          TAG=`echo $(git describe --tags --abbrev=0)`
-          echo "GIT_TAG=${TAG#v}" >> $GITHUB_ENV
+        run: echo "GIT_TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       - name: Prepublish
         env:
           RELEASE_VERSION: ${{ env.GIT_TAG }}


### PR DESCRIPTION
This PR should let us create a new dart release by running:

```
git tag -a v3.22.6 -m "dart release v3.22.6"
git push origin v3.22.6
```

Automated publishing [requires a push to a tag](https://dart.dev/tools/pub/automated-publishing#publishing-packages-using-github-actions) and the action is set up to dynamically update the pubspec to use the current ref as the release version. When the tag version matches the pubspec version, the action should succeed and the dart package should publish.