### PR TITLE
fix: strip v from dart release version

### DIFF
--- a/.github/workflows/publish-dart.yml
+++ b/.github/workflows/publish-dart.yml
@@ -22,7 +22,9 @@ jobs:
       - run: dart test
         working-directory: ./dart
       - name: Set Tag
-        run: echo "GIT_TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+        run: |
+          TAG=`echo ${GITHUB_REF#refs/*/}`
+          echo "GIT_TAG=${TAG#v}" >> $GITHUB_ENV
       - name: Prepublish
         env:
           RELEASE_VERSION: ${{ env.GIT_TAG }}


### PR DESCRIPTION
This fixes the [most-recent deploy's issue](https://github.com/xmtp/proto/actions/runs/4557699398/jobs/8039673671) where it tried to use `v` in the pubspec version by stripping it from the environment variable. This PR should let us create a new dart release by running:

```
git tag -a v3.22.6 -m "dart release v3.22.6"
git push origin v3.22.6
```

Automated publishing [requires a push to a tag](https://dart.dev/tools/pub/automated-publishing#publishing-packages-using-github-actions) and the action is set up to dynamically update the pubspec to use the current ref as the release version. When the tag version matches the pubspec version, the action should succeed and the dart package should publish.