### PR TITLE
chore: add back default issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,28 @@
+name: Report a bug
+description: Report a bug to share an issue you're experiencing.
+title: "Bug: "
+labels: bug
+body:
+- type: markdown
+  attributes:
+    value: |
+      Thank you for taking the time to report a bug. Community contributions like yours are key to the development and adoption of XMTP. Review the following guidelines for reporting a bug:
+        - Include 1 bug per issue. Creating 1 issue per bug will make it easier to assign and track progress on bugs.
+        - Check existing issues to see if your issue has already been reported.
+        - Ensure that the bug is not security-related and can safely be disclosed publicly on GitHub. For information about how to report a security issue, see the **Security** tab in this repo.
+        - Follow the [XMTP code of conduct](https://xmtp.org/community/code-of-conduct).
+- type: textarea
+  id: bug-description
+  attributes:
+    label: Describe the bug
+    description: Provide a clear and concise description of the issue. Attach screenshots, if applicable.
+- type: textarea
+  id: expected-behavior
+  attributes:
+    label: Expected behavior
+    description: Provide a clear and concise description of the behavior you expected. Attach screenshots, if applicable.
+- type: textarea
+  id: reproduce
+  attributes:
+    label: Steps to reproduce the bug
+    description: Provide a clear and concise description of how to reproduce the bug, including any relevant environment details such as SDK version, browser, OS, and device.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Have questions about how to build with XMTP?
+    url: https://github.com/orgs/xmtp/discussions/categories/q-a
+    about: Ask your question and learn with the community in the Q&A discussion forum.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,33 @@
+name: Request a feature
+description: Create a feature request to suggest an idea or enhancement.
+title: "Feature request: "
+labels: enhancement
+body:
+- type: markdown
+  attributes:
+    value: |
+      Thank you for taking the time to request a feature. Community contributions like yours are key to the development and adoption of XMTP. Review the following guidelines for requesting a feature:
+        - Include 1 feature request per issue. Creating 1 issue per request will make it easier to explore and assign a priority to a request.
+        - Check existing issues to see if your feature has already been requested.
+        - Ensure that the feature is not security-related and can safely be disclosed publicly on GitHub. For information about how to report a security issue, see the **Security** tab in this repo.
+        - Follow the [XMTP code of conduct](https://xmtp.org/community/code-of-conduct).
+- type: textarea
+  id: problem-description
+  attributes:
+    label: Is your feature request related to a problem?
+    description: Provide a clear and concise description of the problem to be solved.
+- type: textarea
+  id: solution
+  attributes:
+    label: Describe the solution to the problem
+    description: Provide a clear and concise description of what you want to happen to solve the problem.
+- type: textarea
+  id: usecases
+  attributes:
+    label: Describe the uses cases for the feature
+    description: Provide a clear and concise description of the use cases the feature unlocks.
+- type: textarea
+  id: details
+  attributes:
+    label: Additional details
+    description: Add any other details about your feature request. Attach screenshots, if applicable.


### PR DESCRIPTION
Narrator: [It wasn't additive.](https://github.com/xmtp/proto/pull/69#issuecomment-1490935985)

This PR adds back the issue templates that were provided by https://github.com/xmtp/.github originally.