### PR TITLE
feat: add signature

### DIFF
--- a/proto/v3/message_contents/association.proto
+++ b/proto/v3/message_contents/association.proto
@@ -1,0 +1,20 @@
+// Association types
+syntax = "proto3";
+
+package xmtp.v3.message_contents;
+
+option go_package = "github.com/xmtp/proto/v3/go/v3/message_contents";
+option java_package = "org.xmtp.proto.v3.message.contents";
+
+// EIP191Association is used for all EIP 191 compliant wallet signatures
+message Eip191Association {
+    // The text that was signed, not including the prefix '\0x19Ethereum....'
+    string text = 1;
+    RecoverableEcdaSignature signature = 2;
+}
+
+// RecoverableEcdsaSignature
+message RecoverableEcdaSignature {
+    // Includes recovery id as the last byte
+    bytes bytes = 1;
+}

--- a/proto/v3/message_contents/public_key.proto
+++ b/proto/v3/message_contents/public_key.proto
@@ -4,8 +4,9 @@ syntax = "proto3";
 
 package xmtp.v3.message_contents;
 
-// v4 here since it was already v3 for golang prior to this
-option go_package = "github.com/xmtp/proto/v4/go/message_contents";
+import "v3/message_contents/association.proto";
+
+option go_package = "github.com/xmtp/proto/v3/go/v3/message_contents";
 option java_package = "org.xmtp.proto.v3.message.contents";
 
 // An unsigned public key used by libxmtp
@@ -28,13 +29,14 @@ message VmacUnsignedPublicKey {
 // The purpose of the key is encoded in the signature
 message VmacAccountLinkedKey {
     VmacUnsignedPublicKey key = 1;
-    // TODO AccountLinkedSignature signature = 2;
+    Eip191Association association = 2;
 }
 
 // A key linked to a device (e.g. signed by a device identity key)
 // The purpose of the key is encoded in the signature
 message VmacDeviceLinkedKey {
     VmacUnsignedPublicKey key = 1;
+    // TODO: Define signature format for device linked keys
     // TODO DeviceLinkedSignature signature = 2;
 }
 
@@ -59,8 +61,15 @@ message VmacFallbackKeyRotation {
 }
 
 // A contact bundle served by the server to a requesting client
-message VmacContactBundle {
+message VmacInstallationPublicKeyBundleV1 {
     VmacAccountLinkedKey identity_key = 1;
-    // An unused one time prekey or fallback key returned by the server
-    VmacDeviceLinkedKey prekey = 2;
+    VmacDeviceLinkedKey fallback_key = 2;
+}
+
+// A wrapper for versions of the installation contact bundle to allow
+// upgradeability
+message InstallationContactBundle {
+    oneof version {
+        VmacInstallationPublicKeyBundleV1 v1 = 1;
+    }
 }


### PR DESCRIPTION
## Summary

- Adds EIP-191 association type for wallet signatures
- Renames contact bundle to `InstallationContactBundle`
- Wraps the top level contact in a `version` union to allow for upgradeability later. Given that this is a top-level proto (it gets decoded directly), we need a way to make breaking changes that doesn't involve rotating the topic
- Fix go package versioning.