### PR TITLE
Add v3 invites

### DIFF
--- a/proto/v3/message_contents/invite.proto
+++ b/proto/v3/message_contents/invite.proto
@@ -12,13 +12,11 @@ option java_package = "org.xmtp.proto.v3.message.contents";
 // ciphertext in SealedInvitationV1 and decrypted by the recipient using the
 // provided inviter `InstallationContactBundle`
 message InvitationV1 {
-    // The inviter_wallet_address must match the address derived from the
-    // signature in the inviter contact bundle. Either the
-    // `inviter_wallet_address` or the `recipient_wallet_address` MUST match the
-    // wallet address of the account receiving this invite
-    string inviter_wallet_address = 1;
-    string recipient_wallet_address = 2;
-    string conversation_unique_id = 3;
+    // If the inviter contact bundle has the same wallet address as the current
+    // user, the invitee is the other wallet address in the conversation. If the
+    // inviter contact bundle has a different wallet address, the invitee wallet
+    // address MUST be the wallet address of the recipient of the invite.
+    string invitee_wallet_address = 1;
     // TODO: Decide whether we need a Context field
 }
 

--- a/proto/v3/message_contents/invite.proto
+++ b/proto/v3/message_contents/invite.proto
@@ -1,0 +1,39 @@
+// V3 invite message structure
+syntax = "proto3";
+
+package xmtp.v3.message_contents;
+
+import "v3/message_contents/public_key.proto";
+
+option go_package = "github.com/xmtp/proto/v3/go/v3/message_contents";
+option java_package = "org.xmtp.proto.v3.message.contents";
+
+// InvitationV1 is the encrypted invitation message meant to be encrypted as
+// ciphertext in SealedInvitationV1 and decrypted by the recipient using the
+// provided inviter `InstallationContactBundle`
+message InvitationV1 {
+    // The inviter_wallet_address must match the address derived from the
+    // signature in the inviter contact bundle Either the
+    // `inviter_wallet_address` or the `recipient_wallet_address` MUST match the
+    // wallet address of the account used to decrypt
+    string inviter_wallet_address = 1;
+    string recipient_wallet_address = 2;
+    string conversation_unique_id = 3;
+    // TODO: Decide whether we need a Context field
+}
+
+// SealedInvitationV1 is the encrypted invitation message and the contact of the
+// sender
+message SealedInvitationV1 {
+    // This contains the public key that will be used to decrypt the ciphertext
+    InstallationContactBundle inviter = 1;
+    // Corresponds to an InvitationV1 message
+    bytes ciphertext = 2;
+}
+
+// Wrapper message type
+message SealedInvitation {
+    oneof version {
+        SealedInvitationV1 v1 = 1;
+    }
+}

--- a/proto/v3/message_contents/invite.proto
+++ b/proto/v3/message_contents/invite.proto
@@ -13,9 +13,9 @@ option java_package = "org.xmtp.proto.v3.message.contents";
 // provided inviter `InstallationContactBundle`
 message InvitationV1 {
     // The inviter_wallet_address must match the address derived from the
-    // signature in the inviter contact bundle Either the
+    // signature in the inviter contact bundle. Either the
     // `inviter_wallet_address` or the `recipient_wallet_address` MUST match the
-    // wallet address of the account used to decrypt
+    // wallet address of the account receiving this invite
     string inviter_wallet_address = 1;
     string recipient_wallet_address = 2;
     string conversation_unique_id = 3;

--- a/proto/v3/message_contents/invite.proto
+++ b/proto/v3/message_contents/invite.proto
@@ -22,9 +22,9 @@ message InvitationV1 {
     // TODO: Decide whether we need a Context field
 }
 
-// SealedInvitationV1 is the encrypted invitation message and the contact of the
-// sender
-message SealedInvitationV1 {
+// InvitationEnvelopeV1 is the encrypted invitation message and the contact of
+// the sender
+message InvitationEnvelopeV1 {
     // This contains the public key that will be used to decrypt the ciphertext
     InstallationContactBundle inviter = 1;
     // Corresponds to an InvitationV1 message
@@ -32,8 +32,8 @@ message SealedInvitationV1 {
 }
 
 // Wrapper message type
-message SealedInvitation {
+message InvitationEnvelope {
     oneof version {
-        SealedInvitationV1 v1 = 1;
+        InvitationEnvelopeV1 v1 = 1;
     }
 }

--- a/proto/v3/message_contents/public_key.proto
+++ b/proto/v3/message_contents/public_key.proto
@@ -29,7 +29,9 @@ message VmacUnsignedPublicKey {
 // The purpose of the key is encoded in the signature
 message VmacAccountLinkedKey {
     VmacUnsignedPublicKey key = 1;
-    Eip191Association association = 2;
+    oneof association {
+        Eip191Association eip_191 = 2;
+    }
 }
 
 // A key linked to an installation (e.g. signed by an installation identity key)


### PR DESCRIPTION
## Summary

We need some mechanism of tying vodozemac sessions to a conversation entity. This is particularly relevant for messages to a user's own installations, where the sender and recipient both share the same wallet address (how do I know who I am talking to???). 

This tries to accomplish this in the most minimal way possible.
- Includes the Contact Bundle needed to decrypt the invite
- Include the two wallet addresses that are participating in the conversation. See validation rules below.
- Include a unique identifier for the conversation, which is used to link all the vmac sessions in a convo

## Validation Rules
- The `inviter_wallet_address` MUST match the signature of the `inviter` contact bundle. 
- One of the `inviter_wallet_address` or the `recipient_wallet_address` MUST match the wallet address of the recipient of the message. Otherwise we should reject as a replay/forgery
- If `inviter_wallet_address === my_wallet_address`, the `recipient_wallet_address` is the other person
- If not, we know that the `inviter_wallet_address` is the other person's address

## Notes
- I avoided enumerating all the installations participating in the convo. This list will grow post-invite as installations are added, so we need to go to the network to get the list regardless.
- This provides protection against [Unknown Key Share Attacks](https://gitlab.matrix.org/matrix-org/olm/blob/master/docs/olm.md#message-authentication-concerns). I'm not actually sure how one would do that type of attack in XMTP, given our identities are signed, but we're protected regardless.
