### PR TITLE
Wallet address on association

### DIFF
--- a/proto/v3/message_contents/association.proto
+++ b/proto/v3/message_contents/association.proto
@@ -17,6 +17,7 @@ enum AssociationTextVersion {
 message Eip191Association {
     AssociationTextVersion association_text_version = 1;
     RecoverableEcdsaSignature signature = 2;
+    string wallet_address = 3;
 }
 
 // RecoverableEcdsaSignature


### PR DESCRIPTION
## Summary

In order to make `InstallationContactBundle` fully self-describing and able to be verified, we need to include the `wallet_address` on the association.

Previously we were able to get the intended wallet address for an association from context (for example, the topic the message was found on), but in the case of Invite messages we need it to be explicit.

In either case, if the wallet address does not match the signature, verification will fail and the contact will be rejected.

## Alternatives considered
We _could_ store the full text that was signed instead. This is even longer (containing both the wallet address and public key), and it's messier since we would have to parse and validate that the text conforms to our standards for association text. 

Just storing the hash that was signed is not an option because we need to verify that the signature is coming from a well-formed association text referring to the right wallet and public key.