### PR TITLE
Add is_prekey_message field to sealed metadata

### DIFF
--- a/proto/v3/message_contents/message.proto
+++ b/proto/v3/message_contents/message.proto
@@ -16,6 +16,7 @@ message PadlockMessageSealedMetadata {
     string sender_installation_id = 2;
     string recipient_user_address = 3;
     string recipient_installation_id = 4;
+    bool is_prekey_message = 5;
 }
 
 // Plaintext header included with messages, visible to all


### PR DESCRIPTION
From https://matrix-org.github.io/vodozemac/vodozemac/olm/enum.OlmMessage.html:

> Olm uses two types of messages. The underlying transport protocol must provide a means for recipients to distinguish between them.

When receiving a message, we can decrypt the ciphertext as a prekey message or as a normal message based on the value of this field.