### PR TITLE
Add legacy V2 identity key association

### DIFF
--- a/proto/v3/message_contents/association.proto
+++ b/proto/v3/message_contents/association.proto
@@ -13,6 +13,7 @@ option java_package = "org.xmtp.proto.v3.message.contents";
 enum AssociationTextVersion {
     ASSOCIATION_TEXT_VERSION_UNSPECIFIED = 0;
     ASSOCIATION_TEXT_VERSION_1 = 1;
+    ASSOCIATION_TEXT_VERSION_LEGACY = 100;
 }
 
 // EIP191Association is used for all EIP 191 compliant wallet signatures
@@ -26,8 +27,9 @@ message Eip191Association {
 // and transitively to a wallet address.
 message LegacyV2IdentityAssociation {
     bytes sha256_digest = 1;
-    RecoverableEcdsaSignature signature = 2;
-    LegacyV2AccountLinkedIdentityKey v2_identity_key = 3;
+    RecoverableEcdsaSignature v2_identity_signature = 2;
+    bytes v2_identity_key_secp256k1_uncompressed = 3;
+    Eip191Association v2_wallet_association = 4;
 }
 
 // RecoverableEcdsaSignature

--- a/proto/v3/message_contents/association.proto
+++ b/proto/v3/message_contents/association.proto
@@ -12,8 +12,8 @@ option java_package = "org.xmtp.proto.v3.message.contents";
 // incrementing the entire proto
 enum AssociationTextVersion {
     ASSOCIATION_TEXT_VERSION_UNSPECIFIED = 0;
-    ASSOCIATION_TEXT_VERSION_1 = 1;
-    ASSOCIATION_TEXT_VERSION_LEGACY = 100;
+    ASSOCIATION_TEXT_VERSION_1 = 1; // xmtpv2 create_identity wallet signature
+    ASSOCIATION_TEXT_VERSION_2 = 2;
 }
 
 // EIP191Association is used for all EIP 191 compliant wallet signatures
@@ -28,7 +28,7 @@ message Eip191Association {
 message LegacyV2IdentityAssociation {
     bytes sha256_digest = 1;
     RecoverableEcdsaSignature v2_identity_signature = 2;
-    bytes v2_identity_key_secp256k1_uncompressed = 3;
+    bytes v2_identity_key_bytes = 3;  // embeds a V2 UnsignedPublicKey
     Eip191Association v2_wallet_association = 4;
 }
 

--- a/proto/v3/message_contents/association.proto
+++ b/proto/v3/message_contents/association.proto
@@ -6,19 +6,26 @@ package xmtp.v3.message_contents;
 option go_package = "github.com/xmtp/proto/v3/go/v3/message_contents";
 option java_package = "org.xmtp.proto.v3.message.contents";
 
-// Allows for us to update the format of the association text without
-// incrementing the entire proto
-enum AssociationTextVersion {
-    ASSOCIATION_TEXT_VERSION_UNSPECIFIED = 0;
-    ASSOCIATION_TEXT_VERSION_1 = 1; // xmtpv2 create_identity wallet signature
-    ASSOCIATION_TEXT_VERSION_2 = 2;
-}
-
 // EIP191Association is used for all EIP 191 compliant wallet signatures
 message Eip191Association {
-    AssociationTextVersion association_text_version = 1;
+    reserved 1;
     RecoverableEcdsaSignature signature = 2;
-    string wallet_address = 3;
+    oneof association_text {
+        LegacyCreateIdentityAssociation legacy_v2_wallet_association = 3;
+        InstallationGrantAssociation installation_grant_association = 4;
+    }
+
+    // All of the information needed to construct the Create Identity
+    // association text used in XMTP v2
+    message LegacyCreateIdentityAssociation {
+        string wallet_address = 1;
+    }
+
+    // All of the information needed to construct the Grant Messaging Access
+    // association text used in XMTP v3
+    message InstallationGrantAssociation {
+        string wallet_address = 1;
+    }
 }
 
 // Associates an installation key to the specified legacy XMTP v2 identity,

--- a/proto/v3/message_contents/association.proto
+++ b/proto/v3/message_contents/association.proto
@@ -3,6 +3,8 @@ syntax = "proto3";
 
 package xmtp.v3.message_contents;
 
+import "v3/message_contents/public_key.proto";
+
 option go_package = "github.com/xmtp/proto/v3/go/v3/message_contents";
 option java_package = "org.xmtp.proto.v3.message.contents";
 
@@ -18,6 +20,14 @@ message Eip191Association {
     AssociationTextVersion association_text_version = 1;
     RecoverableEcdsaSignature signature = 2;
     string wallet_address = 3;
+}
+
+// Associates an installation key to the specified legacy XMTP v2 identity,
+// and transitively to a wallet address.
+message LegacyV2IdentityAssociation {
+    bytes sha256_digest = 1;
+    RecoverableEcdsaSignature signature = 2;
+    LegacyV2AccountLinkedIdentityKey v2_identity_key = 3;
 }
 
 // RecoverableEcdsaSignature

--- a/proto/v3/message_contents/association.proto
+++ b/proto/v3/message_contents/association.proto
@@ -10,31 +10,31 @@ option java_package = "org.xmtp.proto.v3.message.contents";
 message Eip191Association {
     reserved 1;
     RecoverableEcdsaSignature signature = 2;
-    oneof association_text {
-        LegacyCreateIdentityAssociation legacy_v2_wallet_association = 3;
-        InstallationGrantAssociation installation_grant_association = 4;
+    oneof association_data {
+        CreateIdentityAssociationData create_identity_data = 3;
+        InstallationGrantAssociationData installation_grant_data = 4;
     }
 
-    // All of the information needed to construct the Create Identity
+    // Legacy - all of the information needed to construct the Create Identity
     // association text used in XMTP v2
-    message LegacyCreateIdentityAssociation {
+    message CreateIdentityAssociationData {
         string wallet_address = 1;
     }
 
     // All of the information needed to construct the Grant Messaging Access
     // association text used in XMTP v3
-    message InstallationGrantAssociation {
+    message InstallationGrantAssociationData {
         string wallet_address = 1;
     }
 }
 
-// Associates an installation key to the specified legacy XMTP v2 identity,
+// Legacy - Associates an installation key to a legacy XMTP v2 identity,
 // and transitively to a wallet address.
-message LegacyV2IdentityAssociation {
-    bytes sha256_digest = 1;
-    RecoverableEcdsaSignature v2_identity_signature = 2;
-    bytes v2_identity_key_bytes = 3;  // embeds a V2 UnsignedPublicKey
-    Eip191Association v2_wallet_association = 4;
+message IdentityKeyAssociation {
+    // SECP256k1/SHA256 signature
+    RecoverableEcdsaSignature identity_signature = 1;
+    bytes identity_key_bytes = 2;  // embeds a V2 UnsignedPublicKey
+    Eip191Association identity_key_wallet_association = 3;
 }
 
 // RecoverableEcdsaSignature

--- a/proto/v3/message_contents/association.proto
+++ b/proto/v3/message_contents/association.proto
@@ -3,8 +3,6 @@ syntax = "proto3";
 
 package xmtp.v3.message_contents;
 
-import "v3/message_contents/public_key.proto";
-
 option go_package = "github.com/xmtp/proto/v3/go/v3/message_contents";
 option java_package = "org.xmtp.proto.v3.message.contents";
 

--- a/proto/v3/message_contents/message.proto
+++ b/proto/v3/message_contents/message.proto
@@ -25,6 +25,7 @@ message PadlockMessageSealedMetadata {
 message PadlockMessageHeader {
     uint64 sent_ns = 1;
     bytes sealed_metadata = 2;  // PadlockMessageSealedMetadata
+    bool is_invitation = 3;
 }
 
 // The version used for the decrypted padlock message payload

--- a/proto/v3/message_contents/message.proto
+++ b/proto/v3/message_contents/message.proto
@@ -25,7 +25,6 @@ message PadlockMessageSealedMetadata {
 message PadlockMessageHeader {
     uint64 sent_ns = 1;
     bytes sealed_metadata = 2;  // PadlockMessageSealedMetadata
-    bool is_invitation = 3;
 }
 
 // The version used for the decrypted padlock message payload

--- a/proto/v3/message_contents/public_key.proto
+++ b/proto/v3/message_contents/public_key.proto
@@ -35,30 +35,6 @@ message VmacAccountLinkedKey {
     }
 }
 
-// Identity key used in XMTP v2
-message LegacyV2UnsignedPublicIdentityKey {
-    uint64 created_ns = 1;
-    oneof union {
-        Secp256k1Uncompressed secp256k1_uncompressed = 3;
-    }
-
-    // Supported key types
-
-    // EC: SECP256k1
-    message Secp256k1Uncompressed {
-        // uncompressed point with prefix (0x04) [ P || X || Y ], 65 bytes
-        bytes bytes = 1; 
-    }
-}
-
-// Signed identity key used in XMTP v2 (legacy)
-message LegacyV2AccountLinkedIdentityKey {
-    LegacyV2UnsignedPublicIdentityKey key = 1;
-    oneof association {
-        Eip191Association eip_191 = 2;
-    }
-}
-
 // A key linked to an installation (e.g. signed by an installation identity key)
 // The purpose of the key is encoded in the signature
 message VmacInstallationLinkedKey {

--- a/proto/v3/message_contents/public_key.proto
+++ b/proto/v3/message_contents/public_key.proto
@@ -31,7 +31,7 @@ message VmacAccountLinkedKey {
     VmacUnsignedPublicKey key = 1;
     oneof association {
         Eip191Association eip_191 = 2;
-        LegacyV2IdentityAssociation v2_identity_association = 3;
+        IdentityKeyAssociation identity_key_association = 3;
     }
 }
 

--- a/proto/v3/message_contents/public_key.proto
+++ b/proto/v3/message_contents/public_key.proto
@@ -31,6 +31,31 @@ message VmacAccountLinkedKey {
     VmacUnsignedPublicKey key = 1;
     oneof association {
         Eip191Association eip_191 = 2;
+        LegacyV2IdentityAssociation v2_identity_association = 3;
+    }
+}
+
+// Identity key used in XMTP v2
+message LegacyV2UnsignedPublicIdentityKey {
+    uint64 created_ns = 1;
+    oneof union {
+        Secp256k1Uncompressed secp256k1_uncompressed = 3;
+    }
+
+    // Supported key types
+
+    // EC: SECP256k1
+    message Secp256k1Uncompressed {
+        // uncompressed point with prefix (0x04) [ P || X || Y ], 65 bytes
+        bytes bytes = 1; 
+    }
+}
+
+// Signed identity key used in XMTP v2 (legacy)
+message LegacyV2AccountLinkedIdentityKey {
+    LegacyV2UnsignedPublicIdentityKey key = 1;
+    oneof association {
+        Eip191Association eip_191 = 2;
     }
 }
 


### PR DESCRIPTION
Needed to test out v3 in current SDK's without introducing breaking changes. Publishing now to avoid conflict with Daria's ramp-up task.