### PR TITLE
Update proto messages

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["bufbuild.vscode-buf", "peterj.proto"]
+}

--- a/proto/v3/message_contents/backup_file.proto
+++ b/proto/v3/message_contents/backup_file.proto
@@ -3,8 +3,6 @@ syntax = "proto3";
 
 package xmtp.v3.message_contents;
 
-import "v3/message_contents/message.proto";
-
 option go_package = "github.com/xmtp/proto/v3/go/v3/message_contents";
 option java_package = "org.xmtp.proto.v3.message.contents";
 
@@ -13,6 +11,6 @@ message MessageBackupEntry {
   uint64 sent_ns = 1;
   string sender_address = 2;
   oneof content {
-    bytes conversation_message_v1 = 3;
+    bytes conversation_message_v1 = 3; // A ConversationMessageV1
   }
 }

--- a/proto/v3/message_contents/backup_file.proto
+++ b/proto/v3/message_contents/backup_file.proto
@@ -1,0 +1,18 @@
+// Message backup file entries
+syntax = "proto3";
+
+package xmtp.v3.message_contents;
+
+import "v3/message_contents/message.proto";
+
+option go_package = "github.com/xmtp/proto/v3/go/v3/message_contents";
+option java_package = "org.xmtp.proto.v3.message.contents";
+
+// A single entry in the MessageBackupFile
+message MessageBackupEntry {
+  uint64 sent_ns = 1;
+  string sender_address = 2;
+  oneof content {
+    bytes conversation_message_v1 = 3;
+  }
+}

--- a/proto/v3/message_contents/encoded_content.proto
+++ b/proto/v3/message_contents/encoded_content.proto
@@ -1,0 +1,42 @@
+// Structure for messages in v3
+syntax = "proto3";
+
+package xmtp.v3.message_contents;
+
+option go_package = "github.com/xmtp/proto/v3/go/v3/message_contents";
+option java_package = "org.xmtp.proto.v3.message.contents";
+
+// ContentTypeId is used to identify the type of content stored in a Message.
+message ContentTypeId {
+  string authority_id = 1; // authority governing this content type
+  string type_id = 2; // type identifier
+  uint32 version_major = 3; // major version of the type
+  uint32 version_minor = 4; // minor version of the type
+}
+
+// Recognized compression algorithms
+// protolint:disable ENUM_FIELD_NAMES_ZERO_VALUE_END_WITH
+enum Compression {
+  COMPRESSION_DEFLATE = 0;
+  COMPRESSION_GZIP = 1;
+}
+
+// protolint:enable ENUM_FIELD_NAMES_ZERO_VALUE_END_WITH
+
+// EncodedContent bundles the content with metadata identifying its type
+// and parameters required for correct decoding and presentation of the content.
+message EncodedContent {
+  // content type identifier used to match the payload with
+  // the correct decoding machinery
+  ContentTypeId type = 1;
+  // optional encoding parameters required to correctly decode the content
+  map<string, string> parameters = 2;
+  // optional fallback description of the content that can be used in case
+  // the client cannot decode or render the content
+  optional string fallback = 3;
+  // optional compression; the value indicates algorithm used to
+  // compress the encoded content bytes
+  optional Compression compression = 5;
+  // encoded content itself
+  bytes content = 4;
+}

--- a/proto/v3/message_contents/message.proto
+++ b/proto/v3/message_contents/message.proto
@@ -60,19 +60,20 @@ message MessagePayload {
   EdDsaSignature header_signature = 1; // Signed MessageHeader
   oneof contents {
     ConversationMessageV1 conversation_message_v1 = 2;
-    // TODO: Add other message types (Backup Request, P4, Backup Response)
+    // TODO: Add other message types
+    // (Message Backup Request, P4, Message Backup Response)
   }
 }
 
 // Combines the plaintext header with the encrypted payload
 message MessageEnvelope {
   // First version of the envelope format
-  message V1Envelope {
+  message EnvelopeV1 {
     bytes header_bytes = 1; // MessageHeader
     bytes ciphertext = 2; // Encrypted MessagePayload
   }
 
   oneof envelope {
-    V1Envelope v1 = 1;
+    EnvelopeV1 v1 = 1;
   }
 }

--- a/proto/v3/message_contents/message.proto
+++ b/proto/v3/message_contents/message.proto
@@ -12,7 +12,7 @@ option java_package = "org.xmtp.proto.v3.message.contents";
 // Plaintext header included with messages, visible to all
 // Recipients can verify this header has not been tampered with.
 // Servers are unable to verify if the header has been tampered with.
-message MessageHeader {
+message MessageHeaderV1 {
   // SealedSender wrapper for arbitrary bytes
   message SealedSender {
     bytes ephemeral_public_key = 1;
@@ -56,8 +56,8 @@ message ConversationMessageV1 {
 //    sender_installation_id
 // 5. Verify that both the sender_user and recipient_user are partipants of the
 //    conversation referenced by convo_id
-message MessagePayload {
-  EdDsaSignature header_signature = 1; // Signed MessageHeader
+message MessagePayloadV1 {
+  EdDsaSignature header_signature = 1; // Signature of the header_bytes
   oneof contents {
     ConversationMessageV1 conversation_message_v1 = 2;
     // TODO: Add other message types
@@ -69,8 +69,8 @@ message MessagePayload {
 message MessageEnvelope {
   // First version of the envelope format
   message EnvelopeV1 {
-    bytes header_bytes = 1; // MessageHeader
-    bytes ciphertext = 2; // Encrypted MessagePayload
+    bytes header_bytes = 1; // MessageHeaderV1
+    bytes ciphertext = 2; // Encrypted MessagePayloadV1
   }
 
   oneof envelope {

--- a/proto/v3/message_contents/message.proto
+++ b/proto/v3/message_contents/message.proto
@@ -59,7 +59,9 @@ message ConversationMessageV1 {
 message MessagePayloadV1 {
   EdDsaSignature header_signature = 1; // Signature of the header_bytes
   oneof contents {
-    ConversationMessageV1 conversation_message_v1 = 2;
+    // We store this as bytes so that it can be safely used
+    // to derive the message_id
+    bytes conversation_message_v1 = 2; // ConversationMessageV1
     // TODO: Add other message types
     // (Message Backup Request, P4, Message Backup Response)
   }

--- a/proto/v3/message_contents/message.proto
+++ b/proto/v3/message_contents/message.proto
@@ -4,33 +4,42 @@ syntax = "proto3";
 package xmtp.v3.message_contents;
 
 import "v3/message_contents/association.proto";
+import "v3/message_contents/encoded_content.proto";
 
 option go_package = "github.com/xmtp/proto/v3/go/v3/message_contents";
 option java_package = "org.xmtp.proto.v3.message.contents";
 
-// Metadata that is encrypted via SealedSender and only visible to the recipient
-// Currently we do not actually encrypt this, actual implementation of
-// SealedSender will be added shortly.
-message PadlockMessageSealedMetadata {
-  string sender_user_address = 1;
-  string sender_installation_id = 2;
-  string recipient_user_address = 3;
-  string recipient_installation_id = 4;
-  bool is_prekey_message = 5;
-}
-
 // Plaintext header included with messages, visible to all
 // Recipients can verify this header has not been tampered with.
 // Servers are unable to verify if the header has been tampered with.
-message PadlockMessageHeader {
+message MessageHeader {
+  // SealedSender wrapper for arbitrary bytes
+  message SealedSender {
+    bytes ephemeral_public_key = 1;
+    bytes ephemeral_static_key = 2;
+    bytes encrypted_message = 3; // Will be serialized Metadata
+  }
+
+  // Metadata that is encrypted via SealedSender and only visible to
+  // the recipient
+  message Metadata {
+    string sender_user_address = 1;
+    string sender_installation_id = 2;
+    string recipient_user_address = 3;
+    string recipient_installation_id = 4;
+    bool is_prekey_message = 5;
+  }
+
+  // sent_ns is included to protect against replays of the
+  // header signature
   uint64 sent_ns = 1;
-  bytes sealed_metadata = 2; // PadlockMessageSealedMetadata
+  SealedSender sealed_metadata = 2; // SealedMetadata
 }
 
-// The version used for the decrypted padlock message payload
-enum PadlockMessagePayloadVersion {
-  PADLOCK_MESSAGE_PAYLOAD_VERSION_UNSPECIFIED = 0;
-  PADLOCK_MESSAGE_PAYLOAD_VERSION_ONE = 1;
+// Conversation messages are the primary message type (user to user messages)
+message ConversationMessageV1 {
+  string convo_id = 1;
+  EncodedContent encoded_content = 2;
 }
 
 // Encrypted body included with messages, only visible to recipients
@@ -47,15 +56,23 @@ enum PadlockMessagePayloadVersion {
 //    sender_installation_id
 // 5. Verify that both the sender_user and recipient_user are partipants of the
 //    conversation referenced by convo_id
-message PadlockMessagePayload {
-  PadlockMessagePayloadVersion message_version = 1;
-  EdDsaSignature header_signature = 2; // Signs PadlockMessageHeader
-  string convo_id = 3;
-  bytes content_bytes = 4; // EncodedContent
+message MessagePayload {
+  EdDsaSignature header_signature = 1; // Signed MessageHeader
+  oneof contents {
+    ConversationMessageV1 conversation_message_v1 = 2;
+    // TODO: Add other message types (Backup Request, P4, Backup Response)
+  }
 }
 
 // Combines the plaintext header with the encrypted payload
-message PadlockMessageEnvelope {
-  bytes header_bytes = 1; // PadlockMessageHeader
-  bytes ciphertext = 2; // Encrypted PadlockMessagePayload
+message MessageEnvelope {
+  // First version of the envelope format
+  message V1Envelope {
+    bytes header_bytes = 1; // MessageHeader
+    bytes ciphertext = 2; // Encrypted MessagePayload
+  }
+
+  oneof envelope {
+    V1Envelope v1 = 1;
+  }
 }


### PR DESCRIPTION
## Summary

Updates the Protobuf message types in V3.

The goals of these changes are:

1. Ensure backwards/forwards compatibility for outermost message envelopes. We only have a single inbound topic in V3, so we want to avoid protobuf decoding failures for any valid message sent to that topic.
2. Add support for message types that live outside of a conversation. For example, `MessageBackupRequest` and `MessageBackupResponse` messages are always sent from another installation and don't fit into the typical conversation model. They don't need to be wrapped in `EncodedContent`
3. Add support for [SealedSender](https://github.com/xmtp/libxmtp/pull/266) on headers
4. Remove any mention of Padlock

## Notes
I copied the `EncodedContent` message format in to the V3 folder verbatim. This is mostly just so that V3 never has to reference V2 types, which allows us to import more narrowly and will make the eventual deprecation of V2 types easier.