### PR TITLE
Add `GetConversationHmacKeysRequest` proto

### DIFF
--- a/proto/keystore_api/v1/keystore.proto
+++ b/proto/keystore_api/v1/keystore.proto
@@ -295,6 +295,11 @@ message TopicMap {
   map<string, TopicData> topics = 1;
 }
 
+// Used to get a mapping of conversation topics to their HMAC keys
+message GetConversationHmacKeysRequest {
+  repeated string topics = 1;
+}
+
 // A mapping of topics to their HMAC keys
 message GetConversationHmacKeysResponse {
   // HmacKeyData wraps the HMAC key and the number of 30 day periods since epoch


### PR DESCRIPTION
this new proto will be used to _optionally_ specify topics to include in HMAC key results.