### PR TITLE
fix: update swift generation with mls

### DIFF
--- a/dev/swift/generate
+++ b/dev/swift/generate
@@ -39,7 +39,6 @@ docker run --rm -i -v${PWD}:/code xmtp/protoc-swift \
   mls/api/v1/mls.proto \
   mls/database/intents.proto \
   mls/message_contents/group_metadata.proto \
-  mls/message_contents/content.proto \
   mls/message_contents/transcript_messages.proto \
   mls/message_contents/credential.proto \
   mls/message_contents/association.proto

--- a/dev/swift/generate
+++ b/dev/swift/generate
@@ -35,4 +35,11 @@ docker run --rm -i -v${PWD}:/code xmtp/protoc-swift \
   message_contents/content.proto \
   message_contents/private_preferences.proto \
   message_contents/signed_payload.proto \
-  message_contents/ecies.proto
+  message_contents/ecies.proto \
+  mls/api/v1/mls.proto \
+  mls/database/intents.proto \
+  mls/message_contents/group_metadata.proto \
+  mls/message_contents/content.proto \
+  mls/message_contents/transcript_messages.proto \
+  mls/message_contents/credential.proto \
+  mls/message_contents/association.proto


### PR DESCRIPTION
I forgot to use semantic releases for my last release so updated swift generation as well.