### PR TITLE
Use uint64 for block number

### DIFF
--- a/proto/identity/associations/signature.proto
+++ b/proto/identity/associations/signature.proto
@@ -25,14 +25,14 @@ message Erc1271Signature {
   // https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-10.md
   string contract_address = 1;
   // Specify the block height to verify the signature against
-  int64 block_height = 2;
+  uint64 block_height = 2;
   // The actual signature bytes
   bytes signature = 3;
 }
 
 // An existing address on xmtpv2 may have already signed a legacy identity key
 // of type SignedPublicKey via the 'Create Identity' signature.
-// For migration to xmtpv3, the legacy key is permitted to sign on behalf of the 
+// For migration to xmtpv3, the legacy key is permitted to sign on behalf of the
 // address to create a matching xmtpv3 installation key.
 // This signature type can ONLY be used for CreateXid and AddAssociation
 // payloads, and can only be used once in xmtpv3.

--- a/proto/identity/associations/signature.proto
+++ b/proto/identity/associations/signature.proto
@@ -24,8 +24,8 @@ message Erc1271Signature {
   // CAIP-10 contract address
   // https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-10.md
   string contract_address = 1;
-  // Specify the block height to verify the signature against
-  uint64 block_height = 2;
+  // Specify the block number to verify the signature against
+  uint64 block_number = 2;
   // The actual signature bytes
   bytes signature = 3;
 }


### PR DESCRIPTION
Rename `block_height` to `block_number` given that ethers.rs and ethers.ts use the `block number`, want to be consistent.

Use `uint64` for block_number instead of `int64`.