### PR TITLE
feat: update group mutable metadata to use map for upgradability

### DIFF
--- a/proto/mls/database/intents.proto
+++ b/proto/mls/database/intents.proto
@@ -65,7 +65,8 @@ message RemoveMembersData {
 message UpdateMetadataData {
   // V1 of UpdateMetadataPublishData
   message V1 {
-    string group_name = 1;
+    string field_name = 1;
+    string field_value = 2;
   }
 
   oneof version {

--- a/proto/mls/message_contents/group_metadata.proto
+++ b/proto/mls/message_contents/group_metadata.proto
@@ -24,7 +24,7 @@ enum ConversationType {
 message PolicySet {
   MembershipPolicy add_member_policy = 1;
   MembershipPolicy remove_member_policy = 2;
-  MetadataPolicy update_group_name_policy = 3;
+  map<string, MetadataPolicy> update_metadata_policy = 3;
 }
 
 // A policy that governs adding/removing members or installations

--- a/proto/mls/message_contents/group_mutable_metadata.proto
+++ b/proto/mls/message_contents/group_mutable_metadata.proto
@@ -8,5 +8,5 @@ option java_package = "org.xmtp.proto.mls.message.contents";
 
 // Message for group mutable metadata
 message GroupMutableMetadataV1 {
-  string group_name = 1;
+  map<string, string> attributes = 1;  // Map to store various metadata attributes
 }


### PR DESCRIPTION
By switching to a string,string map for mutable metadata, we can continue to add new metadata fields to libxmtp without breaking groups that have might have members on two different versions of libxmtp. 

