### PR TITLE
Protos for credential validation of Inbox IDs

### DIFF
--- a/proto/mls_validation/v1/service.proto
+++ b/proto/mls_validation/v1/service.proto
@@ -85,7 +85,7 @@ message GetAssociationStateResponse {
 }
 
 // Request to validate an InboxID with the backend service. Ensures an Inbox Id <> Installation key are valid.
-message ValidateInboxIdRequest {
+message ValidateInboxIdsRequest {
   // a single validation request
   message ValidationRequest {
     xmtp.identity.MlsCredential credential = 1;
@@ -97,13 +97,13 @@ message ValidateInboxIdRequest {
 }
 
 // Response to ValidateInboxIdRequest
-message ValidateInboxIdResponse {
+message ValidateInboxIdsResponse {
   // a single validation response
   message ValidationResponse {
     bool is_ok = 1;
     string error_message = 2;
-    string inbox_id = 2;
-    uint64 expiration = 3;
+    string inbox_id = 3;
+    uint64 expiration = 4;
   }
   // List of validation responses
   repeated ValidationResponse responses = 1;

--- a/proto/mls_validation/v1/service.proto
+++ b/proto/mls_validation/v1/service.proto
@@ -90,6 +90,7 @@ message ValidateInboxIdsRequest {
   message ValidationRequest {
     xmtp.identity.MlsCredential credential = 1;
     bytes installation_public_key = 2;
+    repeated xmtp.identity.associations.IdentityUpdate identity_updates = 3;
   }
 
   // list of validation requests

--- a/proto/mls_validation/v1/service.proto
+++ b/proto/mls_validation/v1/service.proto
@@ -18,7 +18,8 @@ service ValidationApi {
   // Gets the final association state for a batch of identity updates
   rpc GetAssociationState(GetAssociationStateRequest) returns (GetAssociationStateResponse) {}
   
-  // Validates InboxID key packages and returns credential information for them, without validating anything.
+  // Validates InboxID key packages and returns credential information for them, without checking
+  // whether an InboxId <> InstallationPublicKey pair is really valid.
   rpc ValidateInboxIdKeyPackages(ValidateKeyPackagesRequest) returns (ValidateInboxIdKeyPackagesResponse) {}
   
   // Validate an InboxID Key Package

--- a/proto/mls_validation/v1/service.proto
+++ b/proto/mls_validation/v1/service.proto
@@ -20,7 +20,7 @@ service ValidationApi {
 
   // Validate an InboxID Key Package
   // need public key possibly
-  rpc ValidateInboxId(ValidateInboxIdRequest) returns (ValidateInboxIdResponse) {}
+  rpc ValidateInboxIds(ValidateInboxIdsRequest) returns (ValidateInboxIdsResponse) {}
 }
 
 // Contains a batch of serialized Key Packages

--- a/proto/mls_validation/v1/service.proto
+++ b/proto/mls_validation/v1/service.proto
@@ -20,7 +20,7 @@ service ValidationApi {
 
   // Validate an InboxID Key Package
   // need public key possibly
-  rpc ValidateInboxId(ValidateInboxIdKeyPackageRequest) returns (ValidateInboxIdKeyPackageResponse) {}
+  rpc ValidateInboxId(ValidateInboxIdRequest) returns (ValidateInboxIdResponse) {}
 }
 
 // Contains a batch of serialized Key Packages

--- a/proto/mls_validation/v1/service.proto
+++ b/proto/mls_validation/v1/service.proto
@@ -17,10 +17,26 @@ service ValidationApi {
   
   // Gets the final association state for a batch of identity updates
   rpc GetAssociationState(GetAssociationStateRequest) returns (GetAssociationStateResponse) {}
-
+  
+  // Validates InboxID key packages and returns credential information for them, without validating anything.
+  rpc ValidateInboxIdKeyPackages(ValidateKeyPackagesRequest) returns (ValidateInboxIdKeyPackagesResponse) {}
+  
   // Validate an InboxID Key Package
   // need public key possibly
   rpc ValidateInboxIds(ValidateInboxIdsRequest) returns (ValidateInboxIdsResponse) {}
+}
+
+// Validates a Inbox-ID Key Package Type
+message ValidateInboxIdKeyPackagesResponse {
+  // one response corresponding to information about one key package
+  message Response {
+    bool is_ok = 1;
+    string error_message = 2;
+    xmtp.identity.MlsCredential credential = 3;
+    bytes installation_public_key = 4;
+  }
+
+  repeated Response responses = 1;
 }
 
 // Contains a batch of serialized Key Packages

--- a/proto/mls_validation/v1/service.proto
+++ b/proto/mls_validation/v1/service.proto
@@ -104,7 +104,6 @@ message ValidateInboxIdsResponse {
     bool is_ok = 1;
     string error_message = 2;
     string inbox_id = 3;
-    uint64 expiration = 4;
   }
   // List of validation responses
   repeated ValidationResponse responses = 1;

--- a/proto/mls_validation/v1/service.proto
+++ b/proto/mls_validation/v1/service.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package xmtp.mls_validation.v1;
 
 import "identity/associations/association.proto";
+import "identity/credential.proto";
 
 option go_package = "github.com/xmtp/proto/v3/go/mls_validation/v1";
 
@@ -16,6 +17,10 @@ service ValidationApi {
   
   // Gets the final association state for a batch of identity updates
   rpc GetAssociationState(GetAssociationStateRequest) returns (GetAssociationStateResponse) {}
+
+  // Validate an InboxID Key Package
+  // need public key possibly
+  rpc ValidateInboxId(ValidateInboxIdKeyPackageRequest) returns (ValidateInboxIdKeyPackageResponse) {}
 }
 
 // Contains a batch of serialized Key Packages
@@ -77,4 +82,29 @@ message GetAssociationStateRequest {
 message GetAssociationStateResponse {
   xmtp.identity.associations.AssociationState association_state = 1;
   xmtp.identity.associations.AssociationStateDiff state_diff = 2;
+}
+
+// Request to validate an InboxID with the backend service. Ensures an Inbox Id <> Installation key are valid.
+message ValidateInboxIdRequest {
+  // a single validation request
+  message ValidationRequest {
+    xmtp.identity.MlsCredential credential = 1;
+    bytes installation_public_key = 2;
+  }
+
+  // list of validation requests
+  repeated ValidationRequest requests = 1;
+}
+
+// Response to ValidateInboxIdRequest
+message ValidateInboxIdResponse {
+  // a single validation response
+  message ValidationResponse {
+    bool is_ok = 1;
+    string error_message = 2;
+    string inbox_id = 2;
+    uint64 expiration = 3;
+  }
+  // List of validation responses
+  repeated ValidationResponse responses = 1;
 }


### PR DESCRIPTION
- Credential validation of inbox IDs
- Validate a InboxID/Installation Public Key from a device
- Rel to https://github.com/xmtp/libxmtp/issues/675