### PR TITLE
Inbox ID updates

### DIFF
--- a/proto/mls/database/intents.proto
+++ b/proto/mls/database/intents.proto
@@ -61,6 +61,22 @@ message RemoveMembersData {
   }
 }
 
+// The data required to make a commit that updates group membership
+// Handles both Add and Remove actions
+message UpdateGroupMembershipData {
+  // V1 of UpdateGroupMembershipPublishData
+  message V1 {
+    // Contains delta of membership updates that need to be applied
+    map<string, uint64> membership_updates = 1;
+    // Contains the list of members that will be removed
+    repeated string removed_members = 2;
+  }
+
+  oneof version {
+    V1 v1 = 1;
+  }
+}
+
 // The data required to update group metadata
 message UpdateMetadataData {
   // V1 of UpdateMetadataPublishData

--- a/proto/mls/message_contents/group_metadata.proto
+++ b/proto/mls/message_contents/group_metadata.proto
@@ -20,7 +20,6 @@ enum ConversationType {
   CONVERSATION_TYPE_UNSPECIFIED = 0;
   CONVERSATION_TYPE_GROUP = 1;
   CONVERSATION_TYPE_DM = 2;
-  CONVERSATION_TYPE_SYNC = 3;
 }
 
 // The set of policies that govern the group

--- a/proto/mls/message_contents/group_metadata.proto
+++ b/proto/mls/message_contents/group_metadata.proto
@@ -9,8 +9,10 @@ option java_package = "org.xmtp.proto.mls.message.contents";
 // Parent message for group metadata
 message GroupMetadataV1 {
   ConversationType conversation_type = 1;
+  // This will be removed soon
   string creator_account_address = 2;
   PolicySet policies = 3;
+  string creator_inbox_id = 4;
 }
 
 // Defines the type of conversation
@@ -18,6 +20,7 @@ enum ConversationType {
   CONVERSATION_TYPE_UNSPECIFIED = 0;
   CONVERSATION_TYPE_GROUP = 1;
   CONVERSATION_TYPE_DM = 2;
+  CONVERSATION_TYPE_SYNC = 3;
 }
 
 // The set of policies that govern the group


### PR DESCRIPTION
## tl;dr

- Adds new `UpdateGroupMembershipData` intent, which will be used for adding/removing members
- Adds `creator_inbox_id` to `GroupMetadataV1` (but doesn't yet remove `creator_account_address`)