### PR TITLE
Tweak: Use int64 instead of uint64 for timestamps

### DIFF
--- a/proto/xmtpv4/message_api/message_api.proto
+++ b/proto/xmtpv4/message_api/message_api.proto
@@ -43,7 +43,7 @@ message PayerEnvelope {
 // but the originator_ns is set by the publishing node
 message UnsignedOriginatorEnvelope {
   uint64 originator_sid = 1;
-  uint64 originator_ns = 2;
+  int64 originator_ns = 2;
   PayerEnvelope payer_envelope = 3;
 }
 


### PR DESCRIPTION
Every library on both server and client uses int64 as the return value for unix_nanos API methods, presumably because it is possible to have timestamps from before the unix epoch. Let's just conform to the standard here rather than having to convert between these types everywhere.