### PR TITLE
Update `MessageHistoryReply` proto

### DIFF
--- a/proto/mls/message_contents/content.proto
+++ b/proto/mls/message_contents/content.proto
@@ -91,14 +91,5 @@ message MessageHistoryReply {
   // Where the messages can be retrieved from
   string url = 2;
   // Generated input 'secret' for the AES Key used to encrypt the message-bundle
-  MessageHistoryKeyType encryption_key = 3;
-  // Generated input 'secret' for the HMAC Key used to sign the bundle_hash
-  MessageHistoryKeyType signing_key = 4;
-  // HMAC Signature of the message-bundle
-  bytes bundle_hash = 5;
-}
-
-// Key used to encrypt or sign the message-bundle
-message MessageHistoryKeyType {
-  oneof key { bytes chacha20_poly1305 = 1; }
+  bytes encryption_key = 3;
 }


### PR DESCRIPTION
# Summary

* Removed `signing_key` field
* Removed `bundle_hash` field
* Removed `MessageHistoryKeyType` proto
* Updated `encryption_key` field to `bytes`

I don't think `MessageHistoryKeyType` makes much sense since it only supports a single type and a `oneof` field does not guarantee a value. With this update, the `encryption_key` field will always have a value, which make a lot more sense to me as it's a requirement.
