### PR TITLE
Add PrivatePreferencesActionMap to keystore

### DIFF
--- a/proto/keystore_api/v1/keystore.proto
+++ b/proto/keystore_api/v1/keystore.proto
@@ -8,6 +8,7 @@ import "message_contents/conversation_reference.proto";
 import "message_contents/invitation.proto";
 import "message_contents/private_key.proto";
 import "message_contents/public_key.proto";
+import "message_contents/private_preferences.proto";
 
 option go_package = "github.com/xmtp/proto/v3/go/keystore_api/v1";
 option java_package = "org.xmtp.proto.keystore.api.v1";
@@ -313,4 +314,9 @@ message GetConversationHmacKeysResponse {
     repeated HmacKeyData values = 1;
   }
   map<string, HmacKeys> hmac_keys = 1;
+}
+
+// A mapping of message hashes to their private preferences action
+message PrivatePreferencesActionMap {
+  map<string, xmtp.message_contents.PrivatePreferencesAction> actions = 1;
 }

--- a/proto/keystore_api/v1/keystore.proto
+++ b/proto/keystore_api/v1/keystore.proto
@@ -7,8 +7,8 @@ import "message_contents/ciphertext.proto";
 import "message_contents/conversation_reference.proto";
 import "message_contents/invitation.proto";
 import "message_contents/private_key.proto";
-import "message_contents/public_key.proto";
 import "message_contents/private_preferences.proto";
+import "message_contents/public_key.proto";
 
 option go_package = "github.com/xmtp/proto/v3/go/keystore_api/v1";
 option java_package = "org.xmtp.proto.keystore.api.v1";


### PR DESCRIPTION
# Summary

This PR adds a new `PrivatePreferencesActionMap` message to allow for encoding a map of unique message hashes to their respective `PrivatePreferencesAction`. This is necessary to properly persist a user's consent list while ensuring that duplicate entries aren't stored/processed.