### PR TITLE
Rename timestamp from server to client

### DIFF
--- a/proto/identity/associations/association.proto
+++ b/proto/identity/associations/association.proto
@@ -20,7 +20,7 @@ message MemberIdentifier {
 message Member {
   MemberIdentifier identifier = 1;
   optional MemberIdentifier added_by_entity = 2;
-  optional uint64 server_timestamp_ns = 3;
+  optional uint64 client_timestamp_ns = 3;
 }
 
 // The first entry of any XID log. The XID must be deterministically derivable


### PR DESCRIPTION
Following some feedback from @neekolas on this PR https://github.com/xmtp/libxmtp/pull/1073#pullrequestreview-2313192842

Decided to switch to using client timestamps over server timestamps due to their availability.