### PR TITLE
Bidirectional BatchSubscribeEnvelopes stream

### DIFF
--- a/proto/xmtpv4/message_api/message_api.proto
+++ b/proto/xmtpv4/message_api/message_api.proto
@@ -78,15 +78,19 @@ message MisbehaviorReport {
   repeated OriginatorEnvelope envelopes = 2;
 }
 
-// Query for envelopes, shared by query and subscribe endpoints
-message EnvelopesQuery {
+message EnvelopesFilter {
   oneof filter {
     // Client queries
     bytes topic = 1;
     // Node queries
     uint32 originator_node_id = 2;
   }
-  VectorClock last_seen = 3;
+}
+
+// Query for envelopes, shared by query and subscribe endpoints
+message EnvelopesQuery {
+  EnvelopesFilter filter = 1;
+  VectorClock last_seen = 2;
 }
 
 // Batch subscribe to envelopes
@@ -95,7 +99,11 @@ message BatchSubscribeEnvelopesRequest {
   message SubscribeEnvelopesRequest {
     EnvelopesQuery query = 1;
   }
-  repeated SubscribeEnvelopesRequest requests = 1;
+  message UnsubscribeEnvelopesRequest {
+    EnvelopesFilter filter = 1;
+  }
+  repeated SubscribeEnvelopesRequest subscribes = 1;
+  repeated UnsubscribeEnvelopesRequest unsubscribes = 2;
 }
 
 // Streamed response for batch subscribe - can be multiple envelopes at once
@@ -125,7 +133,7 @@ message PublishEnvelopeResponse {
 // Replication API
 service ReplicationApi {
   // Subscribe to envelopes
-  rpc BatchSubscribeEnvelopes(BatchSubscribeEnvelopesRequest) returns (stream BatchSubscribeEnvelopesResponse) {
+  rpc BatchSubscribeEnvelopes(stream BatchSubscribeEnvelopesRequest) returns (stream BatchSubscribeEnvelopesResponse) {
     option (google.api.http) = {
       post: "/mls/v2/subscribe-envelopes"
       body: "*"


### PR DESCRIPTION
Gives clients the ability to modify what they are subscribed to without tearing down and re-establishing the stream.

This is a little different from the old server - the client stream consists of deltas to the subscription request, rather than replacing the subscription request entirely. This saves the server implementation from having to tear down and re-establish the stream, and should be a little easier to implement.

https://github.com/xmtp/xmtpd/issues/167