### PR TITLE
Add identity update to client env

### DIFF
--- a/proto/xmtpv4/message_api/message_api.proto
+++ b/proto/xmtpv4/message_api/message_api.proto
@@ -4,6 +4,7 @@ syntax = "proto3";
 package xmtp.xmtpv4;
 
 import "google/api/annotations.proto";
+import "identity/api/v1/identity.proto";
 import "identity/associations/signature.proto";
 import "mls/api/v1/mls.proto";
 
@@ -29,6 +30,7 @@ message ClientEnvelope {
     xmtp.mls.api.v1.RegisterInstallationRequest register_installation = 3;
     xmtp.mls.api.v1.UploadKeyPackageRequest upload_key_package = 4;
     xmtp.mls.api.v1.RevokeInstallationRequest revoke_installation = 5;
+    xmtp.identity.associations.IdentityUpdate identity_update = 6;
   }
   AuthenticatedData aad = 6;
 }

--- a/proto/xmtpv4/message_api/message_api.proto
+++ b/proto/xmtpv4/message_api/message_api.proto
@@ -4,7 +4,7 @@ syntax = "proto3";
 package xmtp.xmtpv4;
 
 import "google/api/annotations.proto";
-import "identity/api/v1/identity.proto";
+import "identity/associations/association.proto";
 import "identity/associations/signature.proto";
 import "mls/api/v1/mls.proto";
 

--- a/proto/xmtpv4/message_api/message_api.proto
+++ b/proto/xmtpv4/message_api/message_api.proto
@@ -30,7 +30,7 @@ message ClientEnvelope {
     xmtp.mls.api.v1.RegisterInstallationRequest register_installation = 3;
     xmtp.mls.api.v1.UploadKeyPackageRequest upload_key_package = 4;
     xmtp.mls.api.v1.RevokeInstallationRequest revoke_installation = 5;
-    xmtp.identity.associations.IdentityUpdate identity_update = 6;
+    xmtp.identity.associations.IdentityUpdate identity_update = 7;
   }
   AuthenticatedData aad = 6;
 }


### PR DESCRIPTION
I think we might have missed an accompanying proto change for https://github.com/xmtp/xmtpd/pull/175, just slipping it in now. I'm unsure why CI didn't catch this though