### PR TITLE
Remove dependency on originator node for blockchain envelopes

### DIFF
--- a/proto/xmtpv4/envelopes/envelopes.proto
+++ b/proto/xmtpv4/envelopes/envelopes.proto
@@ -49,7 +49,7 @@ message UnsignedOriginatorEnvelope {
 
 // An alternative to a signature for blockchain payloads
 message BlockchainProof {
-  uint64 block_number = 1;
+  bytes transaction_hash = 1;
 }
 
 // Signed originator envelope

--- a/proto/xmtpv4/message_api/message_api.proto
+++ b/proto/xmtpv4/message_api/message_api.proto
@@ -41,8 +41,7 @@ message PayerEnvelope {
   xmtp.identity.associations.RecoverableEcdsaSignature payer_signature = 2;
 }
 
-// For blockchain envelopes, the originator_sid is set by the smart contract,
-// but the originator_ns is set by the publishing node
+// For blockchain envelopes, these fields are set by the smart contract
 message UnsignedOriginatorEnvelope {
   uint32 originator_node_id = 1;
   uint64 originator_sequence_id = 2;
@@ -53,7 +52,6 @@ message UnsignedOriginatorEnvelope {
 // An alternative to a signature for blockchain payloads
 message BlockchainProof {
   uint64 block_number = 1;
-  uint32 publisher_node_id = 2;
 }
 
 // Signed originator envelope


### PR DESCRIPTION
We allow anyone to publish to the blockchain directly, so there is no need to specify the `publisher_node_id`. The `originator_ns` field on the `UnsignedOriginatorEnvelope` will be derived from the block time.