### PR TITLE
Update frames actions to sign with InstalltionId

### DIFF
--- a/proto/message_contents/frames.proto
+++ b/proto/message_contents/frames.proto
@@ -37,10 +37,15 @@ message FrameActionBody {
 // The outer payload that will be sent as the `messageBytes` in the
 // `trusted_data` part of the Frames message
 message FrameAction {
-  bytes signature = 1;
-  // The public installation id used to sign.
-  string installation_id = 2;
+  Signature signature = 1 [deprecated = true];
+  // The SignedPublicKeyBundle of the signer, used to link the XMTP signature
+  // with a blockchain account through a chain of signatures.
+  SignedPublicKeyBundle signed_public_key_bundle = 2 [deprecated = true];
   // Serialized FrameActionBody message, so that the signature verification can
   // happen on a byte-perfect representation of the message
   bytes action_body = 3;
+  // The installation signature
+  bytes installation_signature = 4;
+  // The public installation id used to sign.
+  bytes installation_id = 5;
 }

--- a/proto/message_contents/frames.proto
+++ b/proto/message_contents/frames.proto
@@ -37,10 +37,9 @@ message FrameActionBody {
 // The outer payload that will be sent as the `messageBytes` in the
 // `trusted_data` part of the Frames message
 message FrameAction {
-  Signature signature = 1;
-  // The SignedPublicKeyBundle of the signer, used to link the XMTP signature
-  // with a blockchain account through a chain of signatures.
-  SignedPublicKeyBundle signed_public_key_bundle = 2;
+  bytes signature = 1;
+  // The public installation id used to sign.
+  string installation_id = 2;
   // Serialized FrameActionBody message, so that the signature verification can
   // happen on a byte-perfect representation of the message
   bytes action_body = 3;


### PR DESCRIPTION
Now that we sign with an installation instead of a private key bundle lets update the frames action to match that.