### PR TITLE
Remove VectorClock type

### DIFF
--- a/proto/identity/api/v1/identity.proto
+++ b/proto/identity/api/v1/identity.proto
@@ -4,16 +4,15 @@ package xmtp.identity.api.v1;
 
 import "google/api/annotations.proto";
 import "identity/associations/association.proto";
-import "identity/associations/signature.proto";
 import "protoc-gen-openapiv2/options/annotations.proto";
 
 option go_package = "github.com/xmtp/proto/v3/go/mls/api/v1";
 option java_package = "org.xmtp.proto.mls.api.v1";
 option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
   info: {
-    title: "IdentityApi";
-    version: "1.0";
-  };
+    title: "IdentityApi"
+    version: "1.0"
+  }
 };
 
 // RPCs for the new MLS API

--- a/proto/mls_validation/v1/service.proto
+++ b/proto/mls_validation/v1/service.proto
@@ -29,7 +29,11 @@ service ValidationApi {
 
   // Verifies smart contracts
   // This request is proxied from the node, so we'll reuse those messgaes.
-  rpc VerifySmartContractWalletSignatures(xmtp.identity.api.v1.VerifySmartContractWalletSignaturesRequest) returns (xmtp.identity.api.v1.VerifySmartContractWalletSignaturesResponse) {}
+  rpc VerifySmartContractWalletSignatures(
+    xmtp.identity.api.v1.VerifySmartContractWalletSignaturesRequest
+  )  returns (
+    xmtp.identity.api.v1.VerifySmartContractWalletSignaturesResponse
+  ) {}
 }
 
 // Contains a batch of serialized Key Packages

--- a/proto/mls_validation/v1/service.proto
+++ b/proto/mls_validation/v1/service.proto
@@ -4,7 +4,6 @@ package xmtp.mls_validation.v1;
 
 import "identity/api/v1/identity.proto";
 import "identity/associations/association.proto";
-import "identity/associations/signature.proto";
 import "identity/credential.proto";
 
 option go_package = "github.com/xmtp/proto/v3/go/mls_validation/v1";
@@ -30,11 +29,7 @@ service ValidationApi {
 
   // Verifies smart contracts
   // This request is proxied from the node, so we'll reuse those messgaes.
-  rpc VerifySmartContractWalletSignatures(
-    xmtp.identity.api.v1.VerifySmartContractWalletSignaturesRequest
-  )  returns (
-    xmtp.identity.api.v1.VerifySmartContractWalletSignaturesResponse
-  ) {}
+  rpc VerifySmartContractWalletSignatures(xmtp.identity.api.v1.VerifySmartContractWalletSignaturesRequest) returns (xmtp.identity.api.v1.VerifySmartContractWalletSignaturesResponse) {}
 }
 
 // Contains a batch of serialized Key Packages

--- a/proto/xmtpv4/envelopes/envelopes.proto
+++ b/proto/xmtpv4/envelopes/envelopes.proto
@@ -14,7 +14,6 @@ message AuthenticatedData {
   uint32 target_originator = 1;
   bytes target_topic = 2;
   // The last seen entry per originator. Originators that have not been seen are omitted.
-  // Entries MUST be sorted in ascending order, so that smaller node ID's appear first.
   map<uint32, uint64> last_seen = 3;
 }
 

--- a/proto/xmtpv4/envelopes/envelopes.proto
+++ b/proto/xmtpv4/envelopes/envelopes.proto
@@ -9,12 +9,16 @@ import "mls/api/v1/mls.proto";
 
 option go_package = "github.com/xmtp/proto/v3/go/xmtpv4/envelopes";
 
+// The last seen entry per originator. Originators that have not been seen are omitted.
+message Cursor {
+  map<uint32, uint64> node_id_to_sequence_id = 1;
+}
+
 // Data visible to the server that has been authenticated by the client.
 message AuthenticatedData {
   uint32 target_originator = 1;
   bytes target_topic = 2;
-  // The last seen entry per originator. Originators that have not been seen are omitted.
-  map<uint32, uint64> last_seen = 3;
+  Cursor last_seen = 3;
 }
 
 message ClientEnvelope {

--- a/proto/xmtpv4/envelopes/envelopes.proto
+++ b/proto/xmtpv4/envelopes/envelopes.proto
@@ -9,17 +9,13 @@ import "mls/api/v1/mls.proto";
 
 option go_package = "github.com/xmtp/proto/v3/go/xmtpv4/envelopes";
 
-// The last seen entry per originator. Originators that have not been seen are omitted.
-// Entries MUST be sorted in ascending order, so that smaller node ID's appear first.
-message VectorClock {
-  map<uint32, uint64> node_id_to_sequence_id = 1;
-}
-
 // Data visible to the server that has been authenticated by the client.
 message AuthenticatedData {
   uint32 target_originator = 1;
   bytes target_topic = 2;
-  VectorClock last_seen = 3;
+  // The last seen entry per originator. Originators that have not been seen are omitted.
+  // Entries MUST be sorted in ascending order, so that smaller node ID's appear first.
+  map<uint32, uint64> last_seen = 3;
 }
 
 message ClientEnvelope {

--- a/proto/xmtpv4/message_api/message_api.proto
+++ b/proto/xmtpv4/message_api/message_api.proto
@@ -15,8 +15,7 @@ message EnvelopesQuery {
   repeated bytes topics = 1;
   // Node queries
   repeated uint32 originator_node_ids = 2;
-  // The last seen entry per originator. Originators that have not been seen are omitted.
-  map<uint32, uint64> last_seen = 3;
+  xmtp.xmtpv4.envelopes.Cursor last_seen = 3;
 }
 
 // Batch subscribe to envelopes

--- a/proto/xmtpv4/message_api/message_api.proto
+++ b/proto/xmtpv4/message_api/message_api.proto
@@ -30,7 +30,9 @@ message EnvelopesQuery {
   repeated bytes topics = 1;
   // Node queries
   repeated uint32 originator_node_ids = 2;
-  xmtp.xmtpv4.envelopes.VectorClock last_seen = 3;
+  // The last seen entry per originator. Originators that have not been seen are omitted.
+  // Entries MUST be sorted in ascending order, so that smaller node ID's appear first.
+  map<uint32, uint64> last_seen = 3;
 }
 
 // Batch subscribe to envelopes

--- a/proto/xmtpv4/message_api/message_api.proto
+++ b/proto/xmtpv4/message_api/message_api.proto
@@ -31,7 +31,6 @@ message EnvelopesQuery {
   // Node queries
   repeated uint32 originator_node_ids = 2;
   // The last seen entry per originator. Originators that have not been seen are omitted.
-  // Entries MUST be sorted in ascending order, so that smaller node ID's appear first.
   map<uint32, uint64> last_seen = 3;
 }
 


### PR DESCRIPTION
We are no longer referring to this as a 'vector clock', instead it could be more accurately called a cursor.

Seeing as we are renaming anyway, I thought it might be a good opportunity to unnest it, as it complicated the code for using the field. In the original layout, the field could be referred to by three nested names: `last_seen`, `VectorClock`, `node_id_to_sequence_id`.

The issue though is that this is a breaking change, and would require resetting the DB. We may have to do this not just for our own instance of the node, but in any other partner nodes. If this ends up being too difficult, I'm happy to avoid the unnesting and simply rename `VectorClock`->`Cursor`. Although it could be a good thing to run through a breaking change as practice regardless.