### PR TITLE
Expose new metadata endpoint

### DIFF
--- a/proto/xmtpv4/metadata_api/metadata_api.proto
+++ b/proto/xmtpv4/metadata_api/metadata_api.proto
@@ -1,7 +1,7 @@
 // Metadata API
 syntax = "proto3";
 
-package xmtp.xmtpv4.payer_api;
+package xmtp.xmtpv4.metadata_api;
 
 import "google/api/annotations.proto";
 import "xmtpv4/envelopes/envelopes.proto";

--- a/proto/xmtpv4/metadata_api/metadata_api.proto
+++ b/proto/xmtpv4/metadata_api/metadata_api.proto
@@ -1,0 +1,27 @@
+// Metadata API
+syntax = "proto3";
+
+package xmtp.xmtpv4.payer_api;
+
+import "google/api/annotations.proto";
+import "xmtpv4/envelopes/envelopes.proto";
+
+option go_package = "github.com/xmtp/proto/v3/go/xmtpv4/metadata_api";
+
+message GetSyncCursorRequest {
+}
+
+message GetSyncCursorResponse {
+  xmtp.xmtpv4.envelopes.Cursor latest_sync = 1;
+}
+
+
+// Metadata for distributed tracing, debugging and synchronization
+service MetadataApi {
+  rpc GetSyncCursor(GetSyncCursorRequest) returns (GetSyncCursorResponse) {
+    option (google.api.http) = {
+      post: "/mls/v2/metadata/get-sync-cursor"
+      body: "*"
+    };
+  }
+}

--- a/proto/xmtpv4/metadata_api/metadata_api.proto
+++ b/proto/xmtpv4/metadata_api/metadata_api.proto
@@ -15,12 +15,21 @@ message GetSyncCursorResponse {
   xmtp.xmtpv4.envelopes.Cursor latest_sync = 1;
 }
 
+message SubscribeSyncCursorResponse {
+  repeated xmtp.xmtpv4.envelopes.Cursor latest_sync = 1;
+}
 
 // Metadata for distributed tracing, debugging and synchronization
 service MetadataApi {
   rpc GetSyncCursor(GetSyncCursorRequest) returns (GetSyncCursorResponse) {
     option (google.api.http) = {
       post: "/mls/v2/metadata/get-sync-cursor"
+      body: "*"
+    };
+  }
+  rpc SubscribeSyncCursor(GetSyncCursorRequest) returns (SubscribeSyncCursorResponse) {
+    option (google.api.http) = {
+      post: "/mls/v2/metadata/subscribe-sync-cursor"
       body: "*"
     };
   }

--- a/proto/xmtpv4/metadata_api/metadata_api.proto
+++ b/proto/xmtpv4/metadata_api/metadata_api.proto
@@ -15,10 +15,6 @@ message GetSyncCursorResponse {
   xmtp.xmtpv4.envelopes.Cursor latest_sync = 1;
 }
 
-message SubscribeSyncCursorResponse {
-  repeated xmtp.xmtpv4.envelopes.Cursor latest_sync = 1;
-}
-
 // Metadata for distributed tracing, debugging and synchronization
 service MetadataApi {
   rpc GetSyncCursor(GetSyncCursorRequest) returns (GetSyncCursorResponse) {
@@ -27,7 +23,7 @@ service MetadataApi {
       body: "*"
     };
   }
-  rpc SubscribeSyncCursor(GetSyncCursorRequest) returns (SubscribeSyncCursorResponse) {
+  rpc SubscribeSyncCursor(GetSyncCursorRequest) returns (stream GetSyncCursorResponse) {
     option (google.api.http) = {
       post: "/mls/v2/metadata/subscribe-sync-cursor"
       body: "*"


### PR DESCRIPTION
This decentralization endpoint returns the current last_seen vector/cursor as either a get function or a continuous stream.