### PR TITLE
feat: new multi remote attachment content type

### DIFF
--- a/proto/mls/message_contents/content_types/multi_remote_attachment.proto
+++ b/proto/mls/message_contents/content_types/multi_remote_attachment.proto
@@ -20,12 +20,6 @@ message MultiRemoteAttachment {
   
   // Array of attachment information
   repeated RemoteAttachmentInfo attachments = 1;
-
-  // The number of attachments in the attachments array
-  optional uint32 num_attachments = 2;
-  
-  // The maximum content length of an attachment in the attachments array
-  optional uint32 max_attachment_content_length = 3;
 }
 
 message RemoteAttachmentInfo {
@@ -46,4 +40,10 @@ message RemoteAttachmentInfo {
   
   // The URL of the remote content
   string url = 6;
+
+  // The size of the encrypted content in kilobytes
+  optional uint32 content_length_kb = 7; 
+
+  // The filename of the remote content
+  optional string filename = 8;
 }

--- a/proto/mls/message_contents/content_types/multi_remote_attachment.proto
+++ b/proto/mls/message_contents/content_types/multi_remote_attachment.proto
@@ -41,8 +41,8 @@ message RemoteAttachmentInfo {
   // The URL of the remote content
   string url = 6;
 
-  // The size of the encrypted content in kilobytes
-  optional uint32 content_length_kb = 7; 
+  // The size of the encrypted content in bytes (max size of 4GB)
+  optional uint32 content_length = 7; 
 
   // The filename of the remote content
   optional string filename = 8;

--- a/proto/mls/message_contents/content_types/multi_remote_attachment.proto
+++ b/proto/mls/message_contents/content_types/multi_remote_attachment.proto
@@ -1,0 +1,51 @@
+// multi_remote_attachment.proto
+// This file defines the MultiRemoteAttachment message type and is associated with the following ContentTypeId:
+// 
+// ContentTypeId {
+//     authority_id: "xmtp.org",
+//     type_id:      "multiRemoteStaticContent",
+//     version_major: 1,
+//     version_minor: 0,
+// }
+//
+syntax = "proto3";
+
+package xmtp.mls.message_contents.content_types;
+
+option go_package = "github.com/xmtp/proto/v3/go/mls/message_contents/content_types";
+option java_package = "org.xmtp.proto.mls.message_contents.content_types";
+
+// MultiRemoteAttachment message type
+message MultiRemoteAttachment {
+  // A 32 byte array for decrypting the remote content payload
+  bytes secret = 1;
+  
+  // A byte array for the salt used to encrypt the remote content payload
+  bytes salt = 2;
+  
+  // Array of attachment information
+  repeated RemoteAttachmentInfo attachments = 3;
+
+  // The number of attachments in the attachments array
+  optional uint32 num_attachments = 4;
+  
+  // The maximum content length of an attachment in the attachments array
+  optional uint32 max_attachment_content_length = 5;
+}
+
+message RemoteAttachmentInfo {
+  // The SHA256 hash of the remote content
+  string content_digest = 1;
+  
+  // A byte array for the nonce used to encrypt the remote content payload
+  bytes nonce = 2;
+  
+  // The scheme of the URL. Must be "https://"
+  string scheme = 3;
+  
+  // The URL of the remote content
+  string url = 4;
+  
+  // The filename of the remote content
+  string filename = 5;
+}

--- a/proto/mls/message_contents/content_types/multi_remote_attachment.proto
+++ b/proto/mls/message_contents/content_types/multi_remote_attachment.proto
@@ -17,35 +17,33 @@ option java_package = "org.xmtp.proto.mls.message_contents.content_types";
 
 // MultiRemoteAttachment message type
 message MultiRemoteAttachment {
-  // A 32 byte array for decrypting the remote content payload
-  bytes secret = 1;
   
   // Array of attachment information
-  repeated RemoteAttachmentInfo attachments = 2;
+  repeated RemoteAttachmentInfo attachments = 1;
 
   // The number of attachments in the attachments array
-  optional uint32 num_attachments = 3;
+  optional uint32 num_attachments = 2;
   
   // The maximum content length of an attachment in the attachments array
-  optional uint32 max_attachment_content_length = 4;
+  optional uint32 max_attachment_content_length = 3;
 }
 
 message RemoteAttachmentInfo {
   // The SHA256 hash of the remote content
   string content_digest = 1;
+
+  // A 32 byte array for decrypting the remote content payload
+  bytes secret = 2;
   
   // A byte array for the nonce used to encrypt the remote content payload
-  bytes nonce = 2;
+  bytes nonce = 3;
 
   // A byte array for the salt used to encrypt the remote content payload
-  bytes salt = 3;
+  bytes salt = 4;
   
   // The scheme of the URL. Must be "https://"
-  string scheme = 4;
+  string scheme = 5;
   
   // The URL of the remote content
-  string url = 5;
-  
-  // The filename of the remote content
-  string filename = 6;
+  string url = 6;
 }

--- a/proto/mls/message_contents/content_types/multi_remote_attachment.proto
+++ b/proto/mls/message_contents/content_types/multi_remote_attachment.proto
@@ -20,17 +20,14 @@ message MultiRemoteAttachment {
   // A 32 byte array for decrypting the remote content payload
   bytes secret = 1;
   
-  // A byte array for the salt used to encrypt the remote content payload
-  bytes salt = 2;
-  
   // Array of attachment information
-  repeated RemoteAttachmentInfo attachments = 3;
+  repeated RemoteAttachmentInfo attachments = 2;
 
   // The number of attachments in the attachments array
-  optional uint32 num_attachments = 4;
+  optional uint32 num_attachments = 3;
   
   // The maximum content length of an attachment in the attachments array
-  optional uint32 max_attachment_content_length = 5;
+  optional uint32 max_attachment_content_length = 4;
 }
 
 message RemoteAttachmentInfo {
@@ -39,13 +36,16 @@ message RemoteAttachmentInfo {
   
   // A byte array for the nonce used to encrypt the remote content payload
   bytes nonce = 2;
+
+  // A byte array for the salt used to encrypt the remote content payload
+  bytes salt = 3;
   
   // The scheme of the URL. Must be "https://"
-  string scheme = 3;
+  string scheme = 4;
   
   // The URL of the remote content
-  string url = 4;
+  string url = 5;
   
   // The filename of the remote content
-  string filename = 5;
+  string filename = 6;
 }


### PR DESCRIPTION
See https://github.com/xmtp/XIPs/blob/main/XIPs/xip-50-multiple-remote-attachments-content-type.md

>This XIP proposes a new MultiRemoteAttachment content type inspired by the existing RemoteAttachment content type, that instead allows for multiple remote attachments to be sent in a single message.
> Where the RemoteAttachment content is a URL pointing to an encrypted protobuf [EncodedContent](https://github.com/xmtp/proto/blob/9c2c26caa69367684d54919fe29a02cb3666a71c/proto/mls/message_contents/content.proto#L26-L42), the MultiRemoteAttachment content is a protobuf struct containing an array of remote attachment structs, each specifying a URL, as well as a contentDigest, contentLength, nonce, scheme, and filename. 
> The idea being that the multiple remote attachment encoded content parameters will specify a secret key and salt for encrypting/decrypting all attachments, but each attachment will have its own nonce, and contentDigest for validating the integrity of the individual attachments.
