### PR TITLE
add failed installations to intents and welcomes

### DIFF
--- a/proto/mls/database/intents.proto
+++ b/proto/mls/database/intents.proto
@@ -71,7 +71,7 @@ message UpdateGroupMembershipData {
     // Contains the list of members that will be removed
     repeated string removed_members = 2;
     // List of installations that failed to be added due to errors encountered during the evaluation process.
-    optional InstallationIds failed_installations = 3;
+    repeated bytes failed_installations = 3;
   }
 
   oneof version {

--- a/proto/mls/database/intents.proto
+++ b/proto/mls/database/intents.proto
@@ -70,6 +70,8 @@ message UpdateGroupMembershipData {
     map<string, uint64> membership_updates = 1;
     // Contains the list of members that will be removed
     repeated string removed_members = 2;
+    repeated bytes failed_installations = 3;
+
   }
 
   oneof version {

--- a/proto/mls/database/intents.proto
+++ b/proto/mls/database/intents.proto
@@ -70,8 +70,8 @@ message UpdateGroupMembershipData {
     map<string, uint64> membership_updates = 1;
     // Contains the list of members that will be removed
     repeated string removed_members = 2;
-    repeated bytes failed_installations = 3;
-
+    // List of installations that failed to be added due to errors encountered during the evaluation process.
+    optional InstallationIds failed_installations = 3;
   }
 
   oneof version {

--- a/proto/mls/message_contents/group_membership.proto
+++ b/proto/mls/message_contents/group_membership.proto
@@ -10,4 +10,5 @@ option java_package = "org.xmtp.proto.mls.message.contents";
 // Designed to be stored in the group context extension of the MLS group
 message GroupMembership {
   map<string, uint64> members = 1;
+  repeated bytes failed_installations = 2;
 }

--- a/proto/mls/message_contents/group_membership.proto
+++ b/proto/mls/message_contents/group_membership.proto
@@ -6,9 +6,15 @@ package xmtp.mls.message_contents;
 option go_package = "github.com/xmtp/proto/v3/go/mls/message_contents";
 option java_package = "org.xmtp.proto.mls.message.contents";
 
+// Wrapper around a list of repeated Installation IDs
+message InstallationIds {
+  repeated bytes installation_ids = 1;
+}
+
 // Contains a mapping of `inbox_id` -> `sequence_id` for all members of a group.
 // Designed to be stored in the group context extension of the MLS group
 message GroupMembership {
   map<string, uint64> members = 1;
-  repeated bytes failed_installations = 2;
+  // List of installations that failed to be added due to errors encountered during the evaluation process.
+  optional InstallationIds failed_installations =2;
 }

--- a/proto/mls/message_contents/group_membership.proto
+++ b/proto/mls/message_contents/group_membership.proto
@@ -6,15 +6,10 @@ package xmtp.mls.message_contents;
 option go_package = "github.com/xmtp/proto/v3/go/mls/message_contents";
 option java_package = "org.xmtp.proto.mls.message.contents";
 
-// Wrapper around a list of repeated Installation IDs
-message InstallationIds {
-  repeated bytes installation_ids = 1;
-}
-
 // Contains a mapping of `inbox_id` -> `sequence_id` for all members of a group.
 // Designed to be stored in the group context extension of the MLS group
 message GroupMembership {
   map<string, uint64> members = 1;
   // List of installations that failed to be added due to errors encountered during the evaluation process.
-  optional InstallationIds failed_installations =2;
+  repeated bytes failed_installations = 2;
 }


### PR DESCRIPTION
When creating a conversation or DM, if we encounter bad installations (invalid or malformed KeyPackages), we must:
1. Validate and mark them as failed_installations.
2. Store failed_installations in the Welcome message and Intents