### PR TITLE
Change payer envelope to bytes

### DIFF
--- a/proto/xmtpv4/envelopes/envelopes.proto
+++ b/proto/xmtpv4/envelopes/envelopes.proto
@@ -45,7 +45,7 @@ message UnsignedOriginatorEnvelope {
   uint32 originator_node_id = 1;
   uint64 originator_sequence_id = 2;
   int64 originator_ns = 3;
-  PayerEnvelope payer_envelope = 4;
+  bytes payer_envelope_bytes = 4;
   uint64 base_fee_picodollars = 5; // The base fee for the message in picodollars
   uint64 congestion_fee_picodollars = 6; // The congestion fee for the message in picodollars
 }


### PR DESCRIPTION
## tl;dr

For calculating and verifying the fees of a message we need a serialized `PayerEnvelope` to make sure that all clients see the same envelope size.

This is a breaking change