### PR TITLE
Add WelcomeEncryption parameters to proto

### DIFF
--- a/dev/kotlin/generate
+++ b/dev/kotlin/generate
@@ -49,6 +49,7 @@ docker run --platform linux/x86_64 --rm -i -v${PWD}:/code xmtp/protoc-kotlin \
   mls/message_contents/group_mutable_metadata.proto \
   mls/message_contents/content.proto \
   mls/message_contents/transcript_messages.proto \
+  mls/message_contents/wrapper_encryption.proto \
   identity/associations/signature.proto \
   identity/associations/association.proto \
   device_sync/device_sync.proto \

--- a/proto/mls/api/v1/mls.proto
+++ b/proto/mls/api/v1/mls.proto
@@ -5,6 +5,7 @@ package xmtp.mls.api.v1;
 import "google/api/annotations.proto";
 import "google/protobuf/empty.proto";
 import "message_contents/signature.proto";
+import "mls/message_contents/wrapper_encryption.proto";
 import "protoc-gen-openapiv2/options/annotations.proto";
 
 option go_package = "github.com/xmtp/proto/v3/go/mls/api/v1";
@@ -120,6 +121,7 @@ message WelcomeMessage {
     bytes installation_key = 3;
     bytes data = 4;
     bytes hpke_public_key = 5;
+    xmtp.mls.message_contents.WelcomeWrapperAlgorithm wrapper_algorithm = 6;
   }
 
   oneof version {
@@ -134,6 +136,7 @@ message WelcomeMessageInput {
     bytes installation_key = 1;
     bytes data = 2;
     bytes hpke_public_key = 3;
+    xmtp.mls.message_contents.WelcomeWrapperAlgorithm wrapper_algorithm = 4;
   }
 
   oneof version {

--- a/proto/mls/database/intents.proto
+++ b/proto/mls/database/intents.proto
@@ -1,8 +1,9 @@
-// V3 invite message structure
+// Intent protos that are stored in the libxmtp database
 
 syntax = "proto3";
-
 package xmtp.mls.database;
+
+import "mls/message_contents/wrapper_encryption.proto";
 
 option go_package = "github.com/xmtp/proto/v3/go/mls/database";
 option java_package = "org.xmtp.proto.mls.database";
@@ -154,6 +155,7 @@ message PostCommitAction {
   message Installation {
     bytes installation_key = 1;
     bytes hpke_public_key = 2;
+    xmtp.mls.message_contents.WelcomeWrapperAlgorithm welcome_wrapper_algorithm = 3;
   }
   // SendWelcome message
   message SendWelcomes {

--- a/proto/mls/message_contents/wrapper_encryption.proto
+++ b/proto/mls/message_contents/wrapper_encryption.proto
@@ -1,0 +1,20 @@
+// Encryption algorithms for the Welcome Wrapper
+syntax = "proto3";
+
+package xmtp.mls.message_contents;
+
+option go_package = "github.com/xmtp/proto/v3/go/mls/message_contents";
+option java_package = "org.xmtp.proto.mls.message.contents";
+
+// Describes the algorithm used to encrypt the Welcome Wrapper
+enum WelcomeWrapperAlgorithm {
+  WELCOME_WRAPPER_ALGORITHM_UNSPECIFIED = 0;
+  WELCOME_WRAPPER_ALGORITHM_CURVE25519 = 1;
+  WELCOME_WRAPPER_ALGORITHM_XWING_MLKEM_768_DRAFT_6 = 2;
+}
+
+// The KeyPackageExtension that stores the PubKey and the WelcomeWrapperEncryption
+message WelcomeWrapperEncryption {
+  bytes pub_key = 1;
+  WelcomeWrapperAlgorithm algorithm = 2;
+}


### PR DESCRIPTION
### TL;DR

Added support for specifying post-quantum cryptography in MLS welcome messages.

### What changed?

- Created a new `encryption.proto` file with a `WelcomeEncryption` enum that defines encryption types including post-quantum `XWING_MLKEM_768_DRAFT_6`
- Added the encryption ciphersuite field to welcome messages in the MLS API
- Updated the database intents to include encryption type information for installations

### How to test?

1. Verify that the new `WelcomeEncryption` enum is properly defined with the expected values
2. Check that the welcome message structures correctly include the new ciphersuite field
3. Ensure that installation records in the database can properly store the encryption type

### Why make this change?

This change prepares the MLS protocol implementation for post-quantum cryptography support, specifically adding the ability to specify MLKEM-512 as an encryption algorithm for welcome messages. This enhances security by providing quantum-resistant encryption options alongside traditional curve25519.