### PR TITLE
Add FetchKeyPackages

### DIFF
--- a/proto/xmtpv4/message_api/message_api.proto
+++ b/proto/xmtpv4/message_api/message_api.proto
@@ -71,6 +71,20 @@ message GetInboxIdsResponse {
   repeated Response responses = 1;
 }
 
+// Request to get the newest envelope for a given topic
+message GetNewestEnvelopeRequest {
+  repeated bytes topics = 1;
+}
+
+// Response to GetNewestEnvelopeRequest
+message GetNewestEnvelopeResponse {
+  message Response {
+    optional xmtp.xmtpv4.envelopes.OriginatorEnvelope originator_envelope = 1;
+  }
+  // The newest envelope for the given topic OR null if there are no envelopes on the topic
+  repeated Response results = 1;
+}
+
 service ReplicationApi {
   rpc SubscribeEnvelopes(SubscribeEnvelopesRequest) returns (stream SubscribeEnvelopesResponse) {
     option (google.api.http) = {
@@ -96,6 +110,14 @@ service ReplicationApi {
   rpc GetInboxIds(GetInboxIdsRequest) returns (GetInboxIdsResponse) {
     option (google.api.http) = {
       post: "/mls/v2/get-inbox-ids"
+      body: "*"
+    };
+  }
+
+  // Get the newest envelope for each topic
+  rpc GetNewestEnvelope(GetNewestEnvelopeRequest) returns (GetNewestEnvelopeResponse) {
+    option (google.api.http) = {
+      post: "/mls/v2/get-newest-envelope"
       body: "*"
     };
   }


### PR DESCRIPTION
### TL;DR

Added new FetchKeyPackages RPC to the ReplicationApi service.

### What changed?

- Added `FetchKeyPackagesRequest` message with an `installation_keys` field
- Added `FetchKeyPackagesResponse` message with an `originator_envelopes` field
- Added a new `FetchKeyPackages` RPC to the `ReplicationApi` service with HTTP endpoint configuration

### How to test?

- Verify the new RPC can be called with a list of installation keys
- Confirm the response returns the expected originator envelopes
- Test the HTTP endpoint `/mls/v2/get-inbox-ids` with a POST request

### Why make this change?

This change enables clients to fetch key packages for specific installation keys, which is necessary for secure communication setup in the MLS protocol. This functionality allows clients to retrieve the necessary cryptographic material to establish secure channels with other users.