### PR TITLE
Device Sync Content

### DIFF
--- a/.protolint.yaml
+++ b/.protolint.yaml
@@ -102,9 +102,10 @@ lint:
     # REPEATED_FIELD_NAMES_PLURALIZED rule option.
     ## The spec for each rules follows the implementation of https://github.com/gertd/go-pluralize.
     ## Plus, you can refer to this rule's test code.
-    # repeated_field_names_pluralized:
-    #   uncountable_rules:
-    #     - paper
+    repeated_field_names_pluralized:
+      uncountable_rules:
+        - admin_list
+        - super_admin_list
     #   irregular_rules:
     #     Irregular: Regular
 

--- a/proto/device_sync/content.proto
+++ b/proto/device_sync/content.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 package xmtp.device_sync.content;
 
-import "mls/message_contents/content.proto";
 import "device_sync/consent_backup.proto";
+import "mls/message_contents/content.proto";
 
 message DeviceSyncContent {
   oneof content {
@@ -15,12 +15,8 @@ message DeviceSyncContent {
 
 message AcknowledgeKind {
   oneof kind {
-    SyncGroupPresence sync_group_presence = 1;
-    RequestAcknowledge request = 2;
+    RequestAcknowledge request = 1;
   }
-}
-
-message SyncGroupPresence {
 }
 
 message RequestAcknowledge {

--- a/proto/device_sync/content.proto
+++ b/proto/device_sync/content.proto
@@ -7,7 +7,7 @@ import "mls/message_contents/content.proto";
 message DeviceSyncContent {
   oneof content {
     xmtp.mls.message_contents.DeviceSyncRequest request = 1;
-    xmtp.mls.message_contents.DeviceSyncReply payload = 2;
+    xmtp.mls.message_contents.DeviceSyncReply reply = 2;
     AcknowledgeKind acknowledge = 3;
     PreferenceUpdates preference_updates = 4;
   }

--- a/proto/device_sync/content.proto
+++ b/proto/device_sync/content.proto
@@ -1,0 +1,43 @@
+syntax = "proto3";
+package xmtp.device_sync.content;
+
+import "mls/message_contents/content.proto";
+import "device_sync/consent_backup.proto";
+
+message DeviceSyncContent {
+  oneof content {
+    xmtp.mls.message_contents.DeviceSyncRequest request = 1;
+    xmtp.mls.message_contents.DeviceSyncReply payload = 2;
+    AcknowledgeKind acknowledge = 3;
+    PreferenceUpdates preference_updates = 4;
+  }
+}
+
+message AcknowledgeKind {
+  oneof kind {
+    SyncGroupPresence sync_group_presence = 1;
+    RequestAcknowledge request = 2;
+  }
+}
+
+message SyncGroupPresence {
+}
+
+message RequestAcknowledge {
+  string request_id = 1;
+}
+
+message PreferenceUpdates {
+  repeated UserPreferenceUpdate updates = 1;
+}
+
+message UserPreferenceUpdate {
+  oneof update {
+    xmtp.device_sync.consent_backup.ConsentSave consent_update = 1;
+    HmacKeyUpdate hmac_key_update = 2;
+  }
+}
+
+message HmacKeyUpdate {
+  bytes key = 1;
+}

--- a/proto/device_sync/content.proto
+++ b/proto/device_sync/content.proto
@@ -1,9 +1,11 @@
+// Sync group messages
 syntax = "proto3";
 package xmtp.device_sync.content;
 
 import "device_sync/consent_backup.proto";
 import "mls/message_contents/content.proto";
 
+// All potential device sync group messages
 message DeviceSyncContent {
   oneof content {
     xmtp.mls.message_contents.DeviceSyncRequest request = 1;
@@ -13,20 +15,24 @@ message DeviceSyncContent {
   }
 }
 
+// Acknowledges a request and potentially other things in the future.
 message AcknowledgeKind {
   oneof kind {
     RequestAcknowledge request = 1;
   }
 }
 
+// Requets acknowledgement
 message RequestAcknowledge {
   string request_id = 1;
 }
 
+// Preference updates
 message PreferenceUpdates {
   repeated UserPreferenceUpdate updates = 1;
 }
 
+// Preference update
 message UserPreferenceUpdate {
   oneof update {
     xmtp.device_sync.consent_backup.ConsentSave consent_update = 1;
@@ -34,6 +40,7 @@ message UserPreferenceUpdate {
   }
 }
 
+// Hmac key update
 message HmacKeyUpdate {
   bytes key = 1;
 }


### PR DESCRIPTION
### Define Protocol Buffer message structures for device synchronization content in device sync module
* Introduces new Protocol Buffer definitions in [`content.proto`](https://github.com/xmtp/proto/pull/262/files#diff-f9c3d5fbe18115b88a8af6d6419c11934cc6de7f22f97a82a4f0e5948413d51a) establishing message structures for device sync operations including request handling, acknowledgments, and preference updates
* Updates [`protolint.yaml`](https://github.com/xmtp/proto/pull/262/files#diff-78a43d8354af1af40269e37f7a492166c8f58bda146af673b2d99211ae6fdfef) to enable `repeated_field_names_pluralized` rule with exceptions for `admin_list` and `super_admin_list` fields

#### 📍Where to Start
Start with the new [`DeviceSyncContent`](https://github.com/xmtp/proto/pull/262/files#diff-f9c3d5fbe18115b88a8af6d6419c11934cc6de7f22f97a82a4f0e5948413d51a) message definition which serves as the main container for all device sync operations.

----

_[Macroscope](https://app.macroscope.com) summarized e946956._