### PR TITLE
feat: payerEnvelope expiry

### DIFF
--- a/proto/xmtpv4/envelopes/envelopes.proto
+++ b/proto/xmtpv4/envelopes/envelopes.proto
@@ -38,6 +38,7 @@ message PayerEnvelope {
   bytes unsigned_client_envelope = 1; // Protobuf serialized
   xmtp.identity.associations.RecoverableEcdsaSignature payer_signature = 2;
   uint32 target_originator = 3;
+  uint64 expiry_unixtime = 4;
 }
 
 // For blockchain envelopes, these fields are set by the smart contract

--- a/proto/xmtpv4/envelopes/envelopes.proto
+++ b/proto/xmtpv4/envelopes/envelopes.proto
@@ -38,7 +38,7 @@ message PayerEnvelope {
   bytes unsigned_client_envelope = 1; // Protobuf serialized
   xmtp.identity.associations.RecoverableEcdsaSignature payer_signature = 2;
   uint32 target_originator = 3;
-  uint64 expiry_unixtime = 4;
+  int64 expiry_unixtime = 4;
 }
 
 // For blockchain envelopes, these fields are set by the smart contract


### PR DESCRIPTION
### Add expiry_unixtime field to PayerEnvelope message in XMTP v4 protocol definition
Adds a new `expiry_unixtime` field of type `int64` to the `PayerEnvelope` message definition in [envelopes.proto](https://github.com/xmtp/proto/pull/263/files#diff-f812a33b13a82e881082c50bb3818e6aad1d114d1141279972acbc496a645fda). The field is assigned field number 4 in the protocol buffer definition.

#### 📍Where to Start
Start with the `PayerEnvelope` message definition in [envelopes.proto](https://github.com/xmtp/proto/pull/263/files#diff-f812a33b13a82e881082c50bb3818e6aad1d114d1141279972acbc496a645fda) to review the new field addition.

----

_[Macroscope](https://app.macroscope.com) summarized 34f4a3b._