### PR TITLE
Add GetReaderNode to payer api

### DIFF
--- a/proto/xmtpv4/payer_api/payer_api.proto
+++ b/proto/xmtpv4/payer_api/payer_api.proto
@@ -16,12 +16,26 @@ message PublishClientEnvelopesResponse {
   repeated xmtp.xmtpv4.envelopes.OriginatorEnvelope originator_envelopes = 1;
 }
 
+message GetReaderNodeRequest {
+}
+
+message GetReaderNodeResponse {
+  string reader_node_url = 1;
+}
+
 // A narrowly scoped API for publishing messages through a payer
 service PayerApi {
   // Publish envelope
   rpc PublishClientEnvelopes(PublishClientEnvelopesRequest) returns (PublishClientEnvelopesResponse) {
     option (google.api.http) = {
       post: "/mls/v2/payer/publish-client-envelopes"
+      body: "*"
+    };
+  }
+
+  rpc GetReaderNode(GetReaderNodeRequest) returns (GetReaderNodeResponse) {
+    option (google.api.http) = {
+      post: "/mls/v2/payer/get-reader-node"
       body: "*"
     };
   }

--- a/proto/xmtpv4/payer_api/payer_api.proto
+++ b/proto/xmtpv4/payer_api/payer_api.proto
@@ -21,6 +21,7 @@ message GetReaderNodeRequest {
 
 message GetReaderNodeResponse {
   string reader_node_url = 1;
+  repeated string backup_node_urls = 2;
 }
 
 // A narrowly scoped API for publishing messages through a payer


### PR DESCRIPTION
Initial stages of the work around https://github.com/xmtp/libxmtp/issues/1547

The Payer API will expose a `GetReaderNode` method, for clients to retrieve a node URL to read from.

The rpc itself is defined as the bare minimum and will return a randomized node from the pool of healthy nodes. It could be easily extended to include more fields in the future, such as:

```
   message GetReaderNodeRequest {
     optional string region_preference = 1;
     optional bool high_availability = 2;
   }

   message GetReaderNodeResponse {
     string reader_node_url = 1;
     repeated string backup_node_urls = 2;
     optional int64 ttl_seconds = 3;
   }
```