### PR TITLE
feat: golang CI test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,3 +29,19 @@ jobs:
         run: ./gradlew build
       - name: Gradle Run Tests
         run: ./gradlew kotlin:test
+  golang:
+    name: Test (Golang)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout project sources
+        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: 'https://github.com/xmtp/xmtpd'
+          path: xmtpd
+      - uses: actions/setup-go@v5
+      - name: Execute xmtpd protos builder
+        run: |
+          cd xmtpd
+          go tool -modfile=tools/go.mod buf generate ../proto/
+          go build ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: actions/checkout@v4
         with:
-          repository: 'https://github.com/xmtp/xmtpd'
+          repository: 'xmtp/xmtpd'
           path: xmtpd
       - uses: actions/setup-go@v5
       - name: Execute xmtpd protos builder


### PR DESCRIPTION
### Add Golang CI test job to GitHub Actions workflow to test Golang components
The GitHub Actions workflow now includes a new `golang` job that:
* Checks out project sources and the `xmtpd` repository into a subdirectory
* Sets up Go environment using `actions/setup-go@v5`
* Generates protocol buffers from the `proto` directory and builds Go packages

Changes are implemented in [test.yml](https://github.com/xmtp/proto/pull/265/files#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88)

#### 📍Where to Start
Start by reviewing the new `golang` job configuration in [test.yml](https://github.com/xmtp/proto/pull/265/files#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88), which defines the complete workflow for Golang component testing.

----

_[Macroscope](https://app.macroscope.com) summarized ece9112._