### PR TITLE
Resolve cyclical import

### DIFF
--- a/proto/device_sync/content.proto
+++ b/proto/device_sync/content.proto
@@ -3,16 +3,16 @@ syntax = "proto3";
 package xmtp.device_sync.content;
 
 import "device_sync/consent_backup.proto";
-import "mls/message_contents/content.proto";
+import "device_sync/device_sync.proto";
 
 option java_package = "org.xmtp.proto.device_sync";
 
 // All potential device sync group messages
 message DeviceSyncContent {
   oneof content {
-    xmtp.mls.message_contents.DeviceSyncRequest request = 1;
+    DeviceSyncRequest request = 1;
     DeviceSyncAcknowledge acknowledge = 2;
-    xmtp.mls.message_contents.DeviceSyncReply reply = 3;
+    DeviceSyncReply reply = 3;
     PreferenceUpdates preference_updates = 4;
   }
 }
@@ -24,19 +24,56 @@ message DeviceSyncAcknowledge {
 
 // Preference updates
 message PreferenceUpdates {
-  repeated UserPreferenceUpdate updates = 1;
+  repeated PreferenceUpdate updates = 1;
 }
 
 // Preference update
-message UserPreferenceUpdate {
+message PreferenceUpdate {
   oneof update {
     xmtp.device_sync.consent_backup.ConsentSave consent = 1;
     HmacKeyUpdate hmac = 2;
   }
 }
 
+message V1UserPreferenceUpdate {
+  repeated bytes contents = 1;
+}
+
 // Hmac key update
 message HmacKeyUpdate {
   bytes key = 1;
   int64 cycled_at_ns = 2;
+}
+
+// Initiator or new installation id requesting a sync payload send a request
+message DeviceSyncRequest {
+  // Unique identifier for each request
+  string request_id = 1;
+  string pin_code = 2 [deprecated = true];
+  xmtp.device_sync.BackupElementSelection kind = 3 [deprecated = true];
+  xmtp.device_sync.BackupOptions options = 4;
+}
+
+// Pre-existing installation id capable of supplying a sync payload sends this reply
+message DeviceSyncReply {
+  // Must match an existing request_id from a message history request
+  string request_id = 1;
+  // Where the messages can be retrieved from
+  string url = 2;
+  // Encryption key
+  DeviceSyncKeyType encryption_key = 3;
+  // ns unix timestamp of when the reply was sent
+  uint64 timestamp_ns = 4 [deprecated = true];
+  // request kind
+  xmtp.device_sync.BackupElementSelection kind = 5 [deprecated = true];
+
+  // Metadata about the backup
+  xmtp.device_sync.BackupMetadataSave metadata = 6;
+}
+
+// Key used to encrypt the message-bundle
+message DeviceSyncKeyType {
+  oneof key {
+    bytes aes_256_gcm = 1;
+  }
 }

--- a/proto/mls/message_contents/content.proto
+++ b/proto/mls/message_contents/content.proto
@@ -4,7 +4,7 @@ syntax = "proto3";
 
 package xmtp.mls.message_contents;
 
-import "device_sync/device_sync.proto";
+import "device_sync/content.proto";
 
 option go_package = "github.com/xmtp/proto/v3/go/mls/message_contents";
 option java_package = "org.xmtp.proto.mls.message.contents";
@@ -64,11 +64,11 @@ message PlaintextEnvelope {
       // Expected to be EncodedContent
       bytes content = 2;
       // Initiator sends a request to receive sync payload
-      DeviceSyncRequest device_sync_request = 3;
+      xmtp.device_sync.content.DeviceSyncRequest device_sync_request = 3;
       // Some other authorized installation sends a reply with a link to payload
-      DeviceSyncReply device_sync_reply = 4;
+      xmtp.device_sync.content.DeviceSyncReply device_sync_reply = 4;
       // A serialized user preference update
-      UserPreferenceUpdate user_preference_update = 5;
+      xmtp.device_sync.content.V1UserPreferenceUpdate user_preference_update = 5;
     }
   }
 
@@ -78,41 +78,4 @@ message PlaintextEnvelope {
     V1 v1 = 1;
     V2 v2 = 2;
   }
-}
-
-// Initiator or new installation id requesting a sync payload send a request
-message DeviceSyncRequest {
-  // Unique identifier for each request
-  string request_id = 1;
-  string pin_code = 2 [deprecated = true];
-  xmtp.device_sync.BackupElementSelection kind = 3 [deprecated = true];
-  xmtp.device_sync.BackupOptions options = 4;
-}
-
-// Pre-existing installation id capable of supplying a sync payload sends this reply
-message DeviceSyncReply {
-  // Must match an existing request_id from a message history request
-  string request_id = 1;
-  // Where the messages can be retrieved from
-  string url = 2;
-  // Encryption key
-  DeviceSyncKeyType encryption_key = 3;
-  // ns unix timestamp of when the reply was sent
-  uint64 timestamp_ns = 4 [deprecated = true];
-  // request kind
-  xmtp.device_sync.BackupElementSelection kind = 5 [deprecated = true];
-
-  // Metadata about the backup
-  xmtp.device_sync.BackupMetadataSave metadata = 6;
-}
-
-// Key used to encrypt the message-bundle
-message DeviceSyncKeyType {
-  oneof key {
-    bytes aes_256_gcm = 1;
-  }
-}
-
-message UserPreferenceUpdate {
-  repeated bytes contents = 1;
 }


### PR DESCRIPTION
### Resolve cyclical import by relocating device sync message definitions from `mls/message_contents/content.proto` to `device_sync/content.proto`
Reorganizes protocol buffer definitions by moving device sync-related message types (`DeviceSyncRequest`, `DeviceSyncReply`, `DeviceSyncKeyType`) from [content.proto](https://github.com/xmtp/proto/pull/266/files#diff-7d3d3c6cbbba2815231bb1360af20c4bafc14b826fab153771e4a6a2fa60b0ff) to [content.proto](https://github.com/xmtp/proto/pull/266/files#diff-f9c3d5fbe18115b88a8af6d6419c11934cc6de7f22f97a82a4f0e5948413d51a). Updates import statements and message references to use fully qualified names. Renames `UserPreferenceUpdate` to `PreferenceUpdate` and introduces new `V1UserPreferenceUpdate` message type.

#### 📍Where to Start
Start with [content.proto](https://github.com/xmtp/proto/pull/266/files#diff-f9c3d5fbe18115b88a8af6d6419c11934cc6de7f22f97a82a4f0e5948413d51a) which contains the relocated message definitions and updated import statements.

----

_[Macroscope](https://app.macroscope.com) summarized eddf0c4._