### PR TITLE
feat: different approach to expiry

### DIFF
--- a/proto/xmtpv4/envelopes/envelopes.proto
+++ b/proto/xmtpv4/envelopes/envelopes.proto
@@ -38,7 +38,7 @@ message PayerEnvelope {
   bytes unsigned_client_envelope = 1; // Protobuf serialized
   xmtp.identity.associations.RecoverableEcdsaSignature payer_signature = 2;
   uint32 target_originator = 3;
-  int64 expiry_unixtime = 4;
+  uint32 message_retention_days = 4;
 }
 
 // For blockchain envelopes, these fields are set by the smart contract
@@ -49,6 +49,7 @@ message UnsignedOriginatorEnvelope {
   bytes payer_envelope_bytes = 4;
   uint64 base_fee_picodollars = 5; // The base fee for the message in picodollars
   uint64 congestion_fee_picodollars = 6; // The congestion fee for the message in picodollars
+  uint64 expiry_unixtime = 7;
 }
 
 // An alternative to a signature for blockchain payloads


### PR DESCRIPTION
### Move message expiry from PayerEnvelope to UnsignedOriginatorEnvelope and change retention specification to days in XMTP protocol
The protocol buffer definitions in [envelopes.proto](https://github.com/xmtp/proto/pull/267/files#diff-f812a33b13a82e881082c50bb3818e6aad1d114d1141279972acbc496a645fda) have been modified to change how message expiration is handled:

* Renamed `expiry_unixtime` field to `message_retention_days` in `PayerEnvelope` message and changed type from `int64` to `uint32`
* Added new `expiry_unixtime` field of type `uint64` to `UnsignedOriginatorEnvelope` message

#### 📍Where to Start
Start with the protocol definition changes in [envelopes.proto](https://github.com/xmtp/proto/pull/267/files#diff-f812a33b13a82e881082c50bb3818e6aad1d114d1141279972acbc496a645fda), focusing on the modified `PayerEnvelope` and `UnsignedOriginatorEnvelope` message definitions.

----

_[Macroscope](https://app.macroscope.com) summarized c844101._