### PR TITLE
add originator_id and sequence_id to GroupMessageSave

### DIFF
--- a/proto/device_sync/message_backup.proto
+++ b/proto/device_sync/message_backup.proto
@@ -19,6 +19,8 @@ message GroupMessageSave {
   int32 version_minor = 11;
   string authority_id = 12;
   optional bytes reference_id = 13;
+  optional int64 sequence_id = 14;
+  optional int64 originator_id = 15;
 }
 
 // Group message kind


### PR DESCRIPTION
### Add sequence_id and originator_id fields to GroupMessageSave protocol buffer definition
The `GroupMessageSave` message type in [message_backup.proto](https://github.com/xmtp/proto/pull/268/files#diff-ec8b64076a258d0e47270c1ec4d7819e5335ea3418415b8cd467831f64b190fc) has been extended with two new optional `int64` fields:
* `sequence_id` (field 14)
* `originator_id` (field 15)

#### 📍Where to Start
Start by reviewing the protocol buffer definition changes in [message_backup.proto](https://github.com/xmtp/proto/pull/268/files#diff-ec8b64076a258d0e47270c1ec4d7819e5335ea3418415b8cd467831f64b190fc)

----

_[Macroscope](https://app.macroscope.com) summarized f3ca69f._