### PR TITLE
docs: fix invalid link and edit text

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Have questions about how to build with XMTP?
-    url: https://github.com/orgs/xmtp/discussions/categories/q-a
-    about: Ask your question and learn with the community in the Q&A discussion forum.
+    url: https://community.xmtp.org/
+    about: Ask your question and learn with the community in the XMTP Community Forums.


### PR DESCRIPTION
## Changes
url: "https://github.com/orgs/xmtp/discussions/categories/q-a" is invalid, Changed to https://community.xmtp.org/

reason: XMTP Community Forums are the primary space for discussion.

##
*This PR was updated with reference to [xmtp/xmtp-web's ISSUE_TEMPLATE configuration](https://github.com/xmtp/xmtp-web/blob/b87015c6f3e626ed985c6cf63dd94a68eaf9712c/.github/ISSUE_TEMPLATE/config.yml).