### PR TITLE
feat: remove target originator

### DIFF
--- a/proto/xmtpv4/envelopes/envelopes.proto
+++ b/proto/xmtpv4/envelopes/envelopes.proto
@@ -17,6 +17,7 @@ message Cursor {
 
 // Data visible to the server that has been authenticated by the client.
 message AuthenticatedData {
+  // Do NOT reuse tag 1 — previously used by target_originator
   bytes target_topic = 2;
   Cursor depends_on = 3;
   bool is_commit = 4;

--- a/proto/xmtpv4/envelopes/envelopes.proto
+++ b/proto/xmtpv4/envelopes/envelopes.proto
@@ -17,7 +17,6 @@ message Cursor {
 
 // Data visible to the server that has been authenticated by the client.
 message AuthenticatedData {
-  optional uint32 target_originator = 1 [deprecated = true];
   bytes target_topic = 2;
   Cursor depends_on = 3;
   bool is_commit = 4;


### PR DESCRIPTION
### Remove deprecated `target_originator` field from `AuthenticatedData` message in xmtpv4 envelopes protocol buffer definition
This change removes the deprecated `target_originator` field (field number 1) from the `AuthenticatedData` message definition in [envelopes.proto](https://github.com/xmtp/proto/pull/277/files#diff-f812a33b13a82e881082c50bb3818e6aad1d114d1141279972acbc496a645fda). The field was already marked as deprecated and is no longer used in the codebase.

#### 📍Where to Start
Start with the `AuthenticatedData` message definition in [envelopes.proto](https://github.com/xmtp/proto/pull/277/files#diff-f812a33b13a82e881082c50bb3818e6aad1d114d1141279972acbc496a645fda) to see the removal of the deprecated field.



#### Changes since #277 opened

- Added documentation comment to protocol buffer message [f0dcd34]
----

_[Macroscope](https://app.macroscope.com) summarized f0dcd34._