### PR TITLE
Add Welcome Metadata

### DIFF
--- a/proto/mls/api/v1/mls.proto
+++ b/proto/mls/api/v1/mls.proto
@@ -148,7 +148,7 @@ message WelcomeMessageInput {
 
 // This field is encrypted along with the `data` field on the welcome message.
 message WelcomeMetadata {
-    uint64 message_cursor = 1;
+  uint64 message_cursor = 1;
 }
 
 // Full representation of a group message

--- a/proto/mls/api/v1/mls.proto
+++ b/proto/mls/api/v1/mls.proto
@@ -122,7 +122,7 @@ message WelcomeMessage {
     bytes data = 4;
     bytes hpke_public_key = 5;
     xmtp.mls.message_contents.WelcomeWrapperAlgorithm wrapper_algorithm = 6;
-    uint64 message_cursor = 7;
+    bytes welcome_metadata = 7;
   }
 
   oneof version {
@@ -138,12 +138,17 @@ message WelcomeMessageInput {
     bytes data = 2;
     bytes hpke_public_key = 3;
     xmtp.mls.message_contents.WelcomeWrapperAlgorithm wrapper_algorithm = 4;
-    uint64 message_cursor = 5;
+    bytes welcome_metadata = 7;
   }
 
   oneof version {
     V1 v1 = 1;
   }
+}
+
+// This field is encrypted along with the `data` field on the welcome message.
+message WelcomeMetadata {
+    uint64 message_cursor = 1;
 }
 
 // Full representation of a group message


### PR DESCRIPTION
### Add welcome metadata by restructuring WelcomeMessage.V1 and WelcomeMessageInput.V1 to use WelcomeMetadata message for message cursor field in MLS protocol buffer definition
The MLS protocol buffer definition restructures how message cursors are handled in welcome messages by moving the `message_cursor` field from direct inclusion in `WelcomeMessage.V1` and `WelcomeMessageInput.V1` to a new `WelcomeMetadata` message structure. The changes modify field 7 in `WelcomeMessage.V1` from `uint64 message_cursor` to `bytes welcome_metadata`, update `WelcomeMessageInput.V1` by changing field 5 from `uint64 message_cursor` to `bytes welcome_metadata` at field 7, and introduce the new `WelcomeMetadata` message containing the `uint64 message_cursor` field that gets encrypted alongside the data field. See [mls.proto](https://github.com/xmtp/proto/pull/278/files#diff-ecc5f7ce37e02e9997785d5b1a63c97a03b96d475ba95a22a39866591a22b051).

#### 📍Where to Start
Start with the `WelcomeMessage.V1` structure definition in [mls.proto](https://github.com/xmtp/proto/pull/278/files#diff-ecc5f7ce37e02e9997785d5b1a63c97a03b96d475ba95a22a39866591a22b051) to understand the field changes from `message_cursor` to `welcome_metadata`.

----

_[Macroscope](https://app.macroscope.com) summarized 77ac713._