### PR TITLE
Add GetInstallationLatestSequenceID API endpoint

### DIFF
--- a/proto/mls/api/v1/mls.proto
+++ b/proto/mls/api/v1/mls.proto
@@ -125,6 +125,14 @@ service MlsApi {
       body: "*"
     };
   }
+
+  // Get the latest sequence ID for an installation
+  rpc GetInstallationLatestSequenceID(GetInstallationLatestSequenceIDRequest) returns (GetInstallationLatestSequenceIDResponse) {
+    option (google.api.http) = {
+      post: "/mls/v1/get-installation-latest-sequence-id"
+      body: "*"
+    };
+  }
 }
 
 // Full representation of a welcome message
@@ -387,4 +395,12 @@ message BatchQueryCommitLogRequest {
 
 message BatchQueryCommitLogResponse {
   repeated QueryCommitLogResponse responses = 1;
+}
+
+message GetInstallationLatestSequenceIDRequest {
+  bytes installation_key = 1;
+}
+
+message GetInstallationLatestSequenceIDResponse {
+  uint64 sequence_id = 1;
 }


### PR DESCRIPTION
Context
---
In V3, installations are inserted in installations table when they're created, afterwards the row is updated whenever a client sends a request to update an installation.

In D14N, installations are just another OriginatorEnvelope with its own sequenceID. The client will have to track the latest `[originatorID, sequenceID]` carrying their installation, and publish a new one when updating.

This API is the first part of a larger chunk of work: convert current V3 installations into an append-only installations table that can be easily migrated to D14N.

When upgrading to a D14N version, clients will have to query this API to get the latest installation sequenceID. The migrator hardcodes an originatorID of 13 to every installation, so the client will be able to query its own installation envelope when needed and check if it's correct.