### PR TITLE
feat: remove is-commit - will be determined from payload

### DIFF
--- a/proto/xmtpv4/envelopes/envelopes.proto
+++ b/proto/xmtpv4/envelopes/envelopes.proto
@@ -20,7 +20,7 @@ message AuthenticatedData {
   // Do NOT reuse tag 1 — previously used by target_originator
   bytes target_topic = 2;
   Cursor depends_on = 3;
-  // Do NOT reuse tag 1 — previously used by is_commit
+  // Do NOT reuse tag 4 — previously used by is_commit
 }
 
 message ClientEnvelope {

--- a/proto/xmtpv4/envelopes/envelopes.proto
+++ b/proto/xmtpv4/envelopes/envelopes.proto
@@ -20,7 +20,7 @@ message AuthenticatedData {
   // Do NOT reuse tag 1 — previously used by target_originator
   bytes target_topic = 2;
   Cursor depends_on = 3;
-  bool is_commit = 4;
+  // Do NOT reuse tag 1 — previously used by is_commit
 }
 
 message ClientEnvelope {


### PR DESCRIPTION
### Remove `is_commit` field from `AuthenticatedData` message in protocol buffer definition as it will be determined from payload
The `is_commit` boolean field (tag 4) is removed from the `AuthenticatedData` message definition in [proto/xmtpv4/envelopes/envelopes.proto](https://github.com/xmtp/proto/pull/282/files#diff-f812a33b13a82e881082c50bb3818e6aad1d114d1141279972acbc496a645fda). A comment is added indicating that tag 4 should not be reused, following the same pattern as the existing comment for tag 1 which was previously used by `target_originator`.

#### 📍Where to Start
Start with the `AuthenticatedData` message definition in [proto/xmtpv4/envelopes/envelopes.proto](https://github.com/xmtp/proto/pull/282/files#diff-f812a33b13a82e881082c50bb3818e6aad1d114d1141279972acbc496a645fda).

----

_[Macroscope](https://app.macroscope.com) summarized 4007e6c._