### PR TITLE
Sign but do not encrypt commit log entries

### DIFF
--- a/proto/mls/api/v1/mls.proto
+++ b/proto/mls/api/v1/mls.proto
@@ -4,6 +4,7 @@ package xmtp.mls.api.v1;
 
 import "google/api/annotations.proto";
 import "google/protobuf/empty.proto";
+import "identity/associations/signature.proto";
 import "message_contents/signature.proto";
 import "mls/message_contents/commit_log.proto";
 import "mls/message_contents/wrapper_encryption.proto";
@@ -367,7 +368,8 @@ message BatchPublishCommitLogRequest {
 
 message PublishCommitLogRequest {
   bytes group_id = 1;
-  bytes encrypted_commit_log_entry = 2;
+  bytes serialized_commit_log_entry = 2;
+  xmtp.identity.associations.RecoverableEd25519Signature signature = 3;
 }
 
 message QueryCommitLogRequest {

--- a/proto/mls/message_contents/commit_log.proto
+++ b/proto/mls/message_contents/commit_log.proto
@@ -4,6 +4,8 @@ syntax = "proto3";
 
 package xmtp.mls.message_contents;
 
+import "identity/associations/signature.proto";
+
 enum CommitResult {
   COMMIT_RESULT_UNSPECIFIED = 0;
   COMMIT_RESULT_APPLIED = 1;
@@ -31,5 +33,6 @@ message PlaintextCommitLogEntry {
 
 message CommitLogEntry {
   uint64 sequence_id = 1;
-  bytes encrypted_commit_log_entry = 2;
+  bytes serialized_commit_log_entry = 2;
+  xmtp.identity.associations.RecoverableEd25519Signature signature = 3;
 }

--- a/proto/mls/message_contents/group_mutable_metadata.proto
+++ b/proto/mls/message_contents/group_mutable_metadata.proto
@@ -6,15 +6,17 @@ package xmtp.mls.message_contents;
 option go_package = "github.com/xmtp/proto/v3/go/mls/message_contents";
 option java_package = "org.xmtp.proto.mls.message.contents";
 
-
 // Message for group mutable metadata
 message GroupMutableMetadataV1 {
   // Map to store various metadata attributes (Group name, etc.)
-  map<string, string> attributes = 1;  
+  map<string, string> attributes = 1;
   Inboxes admin_list = 2;
   // Creator starts as only super_admin
   // Only super_admin can add/remove other super_admin
   Inboxes super_admin_list = 3;
+  // The ED25519 private key used to sign commit log entries
+  // Must match the first entry in the commit log to be valid
+  optional bytes commit_log_signer = 4;
 }
 
 // Wrapper around a list of repeated Inbox Ids


### PR DESCRIPTION
As discussed, commit log entries will now be signed but not encrypted. This removes a number of race conditions and other issues, stemming from the fact that the commit log can now always be read, regardless of if a secret has been received or not.

The signing key to use for a commit log is determined by the first commit log entry. This key will typically be determined by the group creator, or for pre-existing groups, the first super-admin to publish an entry.

When the signing key for a commit log has been confirmed as the first entry, the installation that created the key may optionally update the mutable metadata to share the private key with the group. Note the group creator may have already pre-seeded the mutable metadata on group creation to save a commit.

I will take care of updating xmtp-node-go and libxmtp to reflect these changes.