### PR TITLE
Proto for Transaction Reference

### DIFF
--- a/proto/mls/message_contents/content_types/transaction_reference.proto
+++ b/proto/mls/message_contents/content_types/transaction_reference.proto
@@ -1,0 +1,41 @@
+// transaction_reference.proto
+// This file defines the TransactionReference message type and is associated with the following ContentTypeId:
+//
+// ContentTypeId {
+//     authority_id: "xmtp.org",
+//     type_id:      "transactionReference",
+//     version_major: 1,
+//     version_minor: 0,
+// }
+
+syntax = "proto3";
+
+package xmtp.mls.message_contents.content_types;
+
+option go_package = "github.com/xmtp/proto/v3/go/mls/message_contents/content_types";
+option java_package = "org.xmtp.proto.mls.message_contents.content_types";
+
+// Metadata message to capture optional transaction details
+message TransactionMetadata {
+  string transaction_type = 1;
+  string currency = 2;
+  uint64 amount = 3;
+  uint32 decimals = 4;
+  string from_address = 5;
+  string to_address = 6;
+}
+
+// TransactionReference message type
+message TransactionReference {
+  // The optional namespace for the networkId (e.g., "eip155")
+  string namespace = 1;
+
+  // The network ID in decimal or hexadecimal format
+  string network_id = 2;
+
+  // The transaction hash (should be unique within network)
+  string reference = 3;
+
+  // Optional metadata for transaction interpretation
+  TransactionMetadata metadata = 4;
+}


### PR DESCRIPTION
### Add Protocol Buffer message definitions for transaction references in the XMTP messaging protocol
Creates a new Protocol Buffer schema file [transaction_reference.proto](https://github.com/xmtp/proto/pull/286/files#diff-a5e6ee9b06beeda909984fbc523e9d103fc5191c34bf9cb1d3adb197510034b3) that defines message types for representing blockchain transaction references within XMTP messages. The file introduces two message definitions: `TransactionMetadata` for capturing optional transaction details including transaction type, currency, amount, decimals, and address information, and `TransactionReference` as the main message type containing namespace, network ID, transaction hash reference, and optional metadata fields.

#### 📍Where to Start
Start with the message type definitions in [transaction_reference.proto](https://github.com/xmtp/proto/pull/286/files#diff-a5e6ee9b06beeda909984fbc523e9d103fc5191c34bf9cb1d3adb197510034b3) to understand the structure of the `TransactionReference` and `TransactionMetadata` messages.

----

_[Macroscope](https://app.macroscope.com) summarized bffba3d._