### PR TITLE
Payer info metadata

### DIFF
--- a/proto/xmtpv4/metadata_api/metadata_api.proto
+++ b/proto/xmtpv4/metadata_api/metadata_api.proto
@@ -22,6 +22,35 @@ message GetVersionResponse {
   string version = 1;
 }
 
+// Whether to group spend by hour or day
+enum PayerInfoGranularity {
+  PAYER_INFO_GRANULARITY_UNSPECIFIED = 0;
+  PAYER_INFO_GRANULARITY_HOUR = 1;
+  PAYER_INFO_GRANULARITY_DAY = 2;
+}
+
+// Get information about payer spend and message counts for a given time period
+message GetPayerInfoRequest {
+  repeated string payer_addresses = 1;
+  PayerInfoGranularity granularity = 2;
+}
+
+// Response to GetPayerInfoRequest
+message GetPayerInfoResponse {
+  message PeriodSummary {
+    uint64 amount_spent_picodollars = 1;
+    uint64 num_messages = 2;
+    uint64 period_start_unix_seconds = 3;
+  }
+
+  message PayerInfo {
+    repeated PeriodSummary period_summaries = 1;
+  }
+
+  // Map of payer address
+  map<string, PayerInfo> payer_info = 1;
+}
+
 // Metadata for distributed tracing, debugging and synchronization
 service MetadataApi {
   rpc GetSyncCursor(GetSyncCursorRequest) returns (GetSyncCursorResponse) {
@@ -41,6 +70,13 @@ service MetadataApi {
   rpc GetVersion(GetVersionRequest) returns (GetVersionResponse) {
     option (google.api.http) = {
       post: "/mls/v2/metadata/version"
+      body: "*"
+    };
+  }
+
+  rpc GetPayerInfo(GetPayerInfoRequest) returns (GetPayerInfoResponse) {
+    option (google.api.http) = {
+      post: "/mls/v2/metadata/get-payer-info"
       body: "*"
     };
   }


### PR DESCRIPTION
### TL;DR

Added a new `GetPayerInfo` RPC to the Metadata API to retrieve payer spend and message count information.

### What changed?

- Added a new `PayerInfoGranularity` enum to specify whether to group data by hour or day
- Created `GetPayerInfoRequest` message with fields for payer addresses, granularity, and time range
- Created `GetPayerInfoResponse` message with nested message types for period summaries and payer info
- Added a new `GetPayerInfo` RPC endpoint to the MetadataApi service with HTTP POST route `/mls/v2/metadata/get-payer-info`

### How to test?

1. Generate the protobuf code
2. Implement the new RPC in the service
3. Make a request to the endpoint with payer addresses, granularity, and time range
4. Verify the response contains the expected payer information with spend and message counts

### Why make this change?

This change enables clients to retrieve and analyze spending patterns and message volume for specific payers over customizable time periods. This information is valuable for billing, usage tracking, and providing insights to users about their platform usage.