### PR TITLE
feat: readd request and intent

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,11 +37,14 @@ jobs:
         uses: actions/checkout@v4
       - uses: actions/checkout@v4
         with:
-          repository: 'xmtp/xmtpd'
+          repository: "xmtp/xmtpd"
           path: xmtpd
       - uses: actions/setup-go@v5
       - name: Execute xmtpd protos builder
         run: |
           cd xmtpd
+          shopt -s globstar
+          rm -rf pkg/proto/**/*.pb.go pkg/proto/**/*.pb.gw.go pkg/proto/**/*.swagger.json
+          shopt -u globstar
           go tool -modfile=tools/go.mod buf generate ../proto/
           go build ./...

--- a/dev/kotlin/generate
+++ b/dev/kotlin/generate
@@ -49,7 +49,7 @@ docker run --platform linux/x86_64 --rm -i -v${PWD}:/code xmtp/protoc-kotlin \
   mls/message_contents/group_mutable_metadata.proto \
   mls/message_contents/commit_log.proto \
   mls/message_contents/content.proto \
-  mls/message_contents/out_of_band.proto \
+  mls/message_contents/oneshot.proto \
   mls/message_contents/transcript_messages.proto \
   mls/message_contents/wrapper_encryption.proto \
   mls/message_contents/content_types/multi_remote_attachment.proto \

--- a/dev/ts/generate
+++ b/dev/ts/generate
@@ -44,7 +44,7 @@ docker run --rm -i -v${PWD}:/code xmtp/protoc \
   mls/message_contents/group_membership.proto \
   mls/message_contents/group_metadata.proto \
   mls/message_contents/group_mutable_metadata.proto \
-  mls/message_contents/out_of_band.proto \
+  mls/message_contents/oneshot.proto \
   mls/message_contents/transcript_messages.proto \
   mls/message_contents/content_types/multi_remote_attachment.proto \
   mls/message_contents/content_types/reaction.proto \

--- a/proto/mls/database/intents.proto
+++ b/proto/mls/database/intents.proto
@@ -38,6 +38,7 @@ message AddressesOrInstallationIds {
   }
 }
 
+// DEPRECATED
 // The data required to add members to a group
 message AddMembersData {
   // V1 of AddMembersPublishData
@@ -50,6 +51,7 @@ message AddMembersData {
   }
 }
 
+// DEPRECATED
 // The data required to remove members from a group
 message RemoveMembersData {
   // V1 of RemoveMembersPublishData
@@ -73,6 +75,19 @@ message UpdateGroupMembershipData {
     repeated string removed_members = 2;
     // List of installations that failed to be added due to errors encountered during the evaluation process.
     repeated bytes failed_installations = 3;
+  }
+
+  oneof version {
+    V1 v1 = 1;
+  }
+}
+
+// The data required to remove and readd existing leaf nodes
+// on the MLS tree. Does not change or update the members list.
+// Used for fork recovery
+message ReaddInstallationsData {
+  message V1 {
+    repeated bytes readded_installations = 1;
   }
 
   oneof version {

--- a/proto/mls/message_contents/content.proto
+++ b/proto/mls/message_contents/content.proto
@@ -5,7 +5,6 @@ syntax = "proto3";
 package xmtp.mls.message_contents;
 
 import "device_sync/content.proto";
-import "mls/message_contents/out_of_band.proto";
 
 option go_package = "github.com/xmtp/proto/v3/go/mls/message_contents";
 option java_package = "org.xmtp.proto.mls.message.contents";
@@ -70,9 +69,11 @@ message PlaintextEnvelope {
       xmtp.device_sync.content.DeviceSyncReply device_sync_reply = 4;
       // A serialized user preference update
       xmtp.device_sync.content.V1UserPreferenceUpdate user_preference_update = 5;
-      // A readd request for fork recovery
-      ReaddRequest readd_request = 6;
     }
+
+    // Removed; moved to oneshot message
+    reserved 6;
+    reserved "readd_request";
   }
 
   // Selector which declares which version of the EncodedContent this

--- a/proto/mls/message_contents/group_metadata.proto
+++ b/proto/mls/message_contents/group_metadata.proto
@@ -3,6 +3,8 @@ syntax = "proto3";
 
 package xmtp.mls.message_contents;
 
+import "mls/message_contents/oneshot.proto";
+
 option go_package = "github.com/xmtp/proto/v3/go/mls/message_contents";
 option java_package = "org.xmtp.proto.mls.message.contents";
 
@@ -14,6 +16,8 @@ message GroupMetadataV1 {
   string creator_inbox_id = 3;
   // Should only be present for CONVERSATION_TYPE_DM
   optional DmMembers dm_members = 4;
+  // Should only be present for CONVERSATION_TYPE_ONESHOT
+  optional xmtp.mls.message_contents.OneshotMessage oneshot_message = 5;
 }
 
 // Defines the type of conversation
@@ -22,6 +26,7 @@ enum ConversationType {
   CONVERSATION_TYPE_GROUP = 1;
   CONVERSATION_TYPE_DM = 2;
   CONVERSATION_TYPE_SYNC = 3;
+  CONVERSATION_TYPE_ONESHOT = 4;
 }
 
 // Wrapper around an Inbox Id

--- a/proto/mls/message_contents/group_mutable_metadata.proto
+++ b/proto/mls/message_contents/group_mutable_metadata.proto
@@ -14,9 +14,9 @@ message GroupMutableMetadataV1 {
   // Creator starts as only super_admin
   // Only super_admin can add/remove other super_admin
   Inboxes super_admin_list = 3;
-  // The ED25519 private key used to sign commit log entries
-  // Must match the first entry in the commit log to be valid
-  optional bytes commit_log_signer = 4;
+  // Top-level commit_log_signer removed in favor of attribute
+  reserved 4;
+  reserved "commit_log_signer";
 }
 
 // Wrapper around a list of repeated Inbox Ids

--- a/proto/mls/message_contents/oneshot.proto
+++ b/proto/mls/message_contents/oneshot.proto
@@ -4,10 +4,19 @@ syntax = "proto3";
 
 package xmtp.mls.message_contents;
 
+message OneshotMessage {
+  oneof message_type {
+    ReaddRequest readd_request = 1;
+  }
+}
+
 // A request sent by an installation to recover from a fork. Other members
 // may remove and readd that installation from the group.
 // XIP: https://community.xmtp.org/t/xip-68-draft-automated-fork-recovery/951
 message ReaddRequest {
   bytes group_id = 1;
-  uint64 commit_log_epoch = 2;
+  // The sequence ID of the latest commit log entry at the time the request
+  // is sent; used to disambiguate cases where an installation forks
+  // and is readded multiple times.
+  uint64 latest_commit_sequence_id = 2;
 }


### PR DESCRIPTION
Changes:
1. Defines a 'oneshot' conversation type
2. Defines a 'readd request' oneshot message, which is used to request fork recovery
3. Defines a readd intent, which is the response to the request. The creator of the intent will publish a commit and then send welcomes to the requester.

__________

Optional notes:
Readd requests need to be sent to superadmins outside of the main group (as the sender is forked), however they still need MLS level authentication and privacy guarantees.

We could create a single-use group and then send a message on it, but given only a single message is needed, an alternative is to embed the message on the immutable metadata of the group itself, and have the recipient 'receive' the message at the time of decrypting the welcome, without persisting the group (ie: use openMLS to construct the group/StagedWelcome in-memory, pull the message from the immutable metadata, then throw the group away). That would allow us to avoid:
- Delays from the sender needing to send an additional message on the group after the welcomes have been sent
- Delays from the recipient needing to sync the group after receiving the welcome to receive the message
- Any unintentional consequences around group storage, syncing on it in the future, calling maybe_update_installations, or rendering it in UI. Also means we don't create a new topic on the server.

Are there traps that I'm falling into here? And please let me know if a better name exists!