### PR TITLE
Endpoint GetNodes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,16 +1,15 @@
 {
-  "protoc": {
-    "compile_on_save": false,
-    "options": ["--proto_path=build/tmp/vendor"]
-  },
-  "[proto3]": {
-    "editor.defaultFormatter": "bufbuild.vscode-buf",
-    "editor.formatOnSave": true
-  },
-  // protolint complains if lines are longer than length 80, display a ruler
-  "editor.rulers": [
-    80
-  ],
-"editor.detectIndentation": false,
-"editor.tabSize": 2
+	"protoc": {
+		"compile_on_save": false,
+		"options": ["--proto_path=build/tmp/vendor"]
+	},
+	"[proto3]": {
+		"editor.defaultFormatter": "bufbuild.vscode-buf",
+		"editor.formatOnSave": true
+	},
+	// protolint complains if lines are longer than length 80, display a ruler
+	"editor.rulers": [80],
+	"editor.detectIndentation": false,
+	"editor.tabSize": 2,
+	"wake.compiler.solc.remappings": []
 }

--- a/proto/xmtpv4/payer_api/payer_api.proto
+++ b/proto/xmtpv4/payer_api/payer_api.proto
@@ -16,12 +16,11 @@ message PublishClientEnvelopesResponse {
   repeated xmtp.xmtpv4.envelopes.OriginatorEnvelope originator_envelopes = 1;
 }
 
-message GetReaderNodeRequest {
+message GetNodesRequest {
 }
 
-message GetReaderNodeResponse {
-  string reader_node_url = 1;
-  repeated string backup_node_urls = 2;
+message GetNodesResponse {
+  repeated string nodes = 1;
 }
 
 // A narrowly scoped API for publishing messages through a payer
@@ -34,9 +33,9 @@ service PayerApi {
     };
   }
 
-  rpc GetReaderNode(GetReaderNodeRequest) returns (GetReaderNodeResponse) {
+  rpc GetNodes(GetNodesRequest) returns (GetNodesResponse) {
     option (google.api.http) = {
-      post: "/mls/v2/payer/get-reader-node"
+      post: "/mls/v2/payer/get-nodes"
       body: "*"
     };
   }


### PR DESCRIPTION
### Rename Payer API endpoint to `PayerApi.GetNodes` and change HTTP path to POST `/mls/v2/payer/get-nodes` to return a `nodes` list
- Rename RPC `PayerApi.GetReaderNode` to `PayerApi.GetNodes`, updating the HTTP binding to POST `/mls/v2/payer/get-nodes` in [payer_api.proto](https://github.com/xmtp/proto/pull/293/files#diff-ff9c61c4661612b323bd2879119e0ea2ee2607686cbfa6a778158ee043e5a7a1).
- Replace `GetReaderNodeRequest`/`GetReaderNodeResponse` with `GetNodesRequest`/`GetNodesResponse` in [payer_api.proto](https://github.com/xmtp/proto/pull/293/files#diff-ff9c61c4661612b323bd2879119e0ea2ee2607686cbfa6a778158ee043e5a7a1); `GetNodesResponse` defines `repeated string nodes = 1`.
- Reformat [.vscode/settings.json](https://github.com/xmtp/proto/pull/293/files#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357) and add `wake.compiler.solc.remappings` as an empty array.

#### 📍Where to Start
Start with the RPC and message changes in [payer_api.proto](https://github.com/xmtp/proto/pull/293/files#diff-ff9c61c4661612b323bd2879119e0ea2ee2607686cbfa6a778158ee043e5a7a1), focusing on the `service PayerApi` definition and the `GetNodesRequest`/`GetNodesResponse` messages.

----

_[Macroscope](https://app.macroscope.com) summarized a2694e7._