### PR TITLE
chore: remove NPM token access

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,6 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm run semantic-release
   kotlin:
     # The `semantic-release` from JS calculates the version tag


### PR DESCRIPTION
### Remove `NPM_TOKEN` from the Release job environment in [release.yml](https://github.com/xmtp/proto/pull/294/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34) to eliminate NPM token access
The Release workflow no longer sets the `NPM_TOKEN` environment variable in its job step.

- Remove `NPM_TOKEN` from the `env` block of the Release job in [release.yml](https://github.com/xmtp/proto/pull/294/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34)

#### 📍Where to Start
Start with the Release job definition in [release.yml](https://github.com/xmtp/proto/pull/294/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34), focusing on the `env` block changes.

----

_[Macroscope](https://app.macroscope.com) summarized efbd5f3._