### PR TITLE
add delete message content type

### DIFF
--- a/dev/kotlin/protoc/Dockerfile
+++ b/dev/kotlin/protoc/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:20-jdk-bullseye AS build
+FROM eclipse-temurin:20-jdk AS build
 
 COPY protoc.sh /opt/protoc
 

--- a/proto/mls/message_contents/content_types/delete_message.proto
+++ b/proto/mls/message_contents/content_types/delete_message.proto
@@ -1,0 +1,22 @@
+// delete_message.proto
+// This file defines the DeleteMessage message type and is associated with the following ContentTypeId:
+//
+// ContentTypeId {
+//     authority_id: "xmtp.org",
+//     type_id:      "deleteMessage",
+//     version_major: 1,
+//     version_minor: 0,
+// }
+//
+syntax = "proto3";
+
+package xmtp.mls.message_contents.content_types;
+
+option go_package = "github.com/xmtp/proto/v3/go/mls/message_contents/content_types";
+option java_package = "org.xmtp.proto.mls.message_contents.content_types";
+
+// DeleteMessage message type
+message DeleteMessage {
+  // ID of the message to delete
+  string message_id = 1;
+}


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add DeleteMessage content type to proto schema to support delete-message payloads in [delete_message.proto](https://github.com/xmtp/proto/pull/308/files#diff-0652eafd93b4367f25cd5e1c1f4ab37f6674a7cbd6716dc1103f4c0cd8fb11cd)
Introduce a `DeleteMessage` protobuf with `string message_id = 1;` and set content type metadata (authority_id `xmtp.org`, type_id `deleteMessage`, version 1.0), plus Go/Java package options.

#### 📍Where to Start
Start with the `DeleteMessage` message definition and file-level options in [delete_message.proto](https://github.com/xmtp/proto/pull/308/files#diff-0652eafd93b4367f25cd5e1c1f4ab37f6674a7cbd6716dc1103f4c0cd8fb11cd).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized b4b52c9.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->