### PR TITLE
Add new BackupOption for exclude_disappearing_messages

### DIFF
--- a/proto/device_sync/device_sync.proto
+++ b/proto/device_sync/device_sync.proto
@@ -34,6 +34,7 @@ message BackupOptions {
   repeated BackupElementSelection elements = 1;
   optional int64 start_ns = 2;
   optional int64 end_ns = 3;
+  bool exclude_disappearing_messages = 4;
 }
 
 // Elements selected for backup


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add `bool BackupOptions.exclude_disappearing_messages = 4` and introduce MLS API RPC `MlsApi.GetNewestGroupMessage` with HTTP GET `/mls/v1/get-newest-group-message`
Add a new `exclude_disappearing_messages` flag to `BackupOptions` in [device_sync.proto](https://github.com/xmtp/proto/pull/313/files#diff-e00caf710d8ffb5e3377aebb8ff571df4ba566bf323790a523c73a905dba891e) and extend MLS with `GetNewestGroupMessage` plus `GroupMessage.V1.is_commit` in [mls.proto](https://github.com/xmtp/proto/pull/313/files#diff-ecc5f7ce37e02e9997785d5b1a63c97a03b96d475ba95a22a39866591a22b051); update CI to `gradle/actions/wrapper-validation@v3`.

#### 📍Where to Start
Start with the MLS changes in [mls.proto](https://github.com/xmtp/proto/pull/313/files#diff-ecc5f7ce37e02e9997785d5b1a63c97a03b96d475ba95a22a39866591a22b051), then review the `BackupOptions` update in [device_sync.proto](https://github.com/xmtp/proto/pull/313/files#diff-e00caf710d8ffb5e3377aebb8ff571df4ba566bf323790a523c73a905dba891e).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 244d900.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->