### PR TITLE
Deprecate Event Backups

### DIFF
--- a/proto/device_sync/device_sync.proto
+++ b/proto/device_sync/device_sync.proto
@@ -16,7 +16,7 @@ message BackupElement {
     xmtp.device_sync.group_backup.GroupSave group = 2;
     xmtp.device_sync.message_backup.GroupMessageSave group_message = 3;
     xmtp.device_sync.consent_backup.ConsentSave consent = 4;
-    xmtp.device_sync.event_backup.EventSave event = 5;
+    xmtp.device_sync.event_backup.EventSave event = 5 [deprecated = true];
   }
 }
 
@@ -42,5 +42,5 @@ enum BackupElementSelection {
   BACKUP_ELEMENT_SELECTION_UNSPECIFIED = 0;
   BACKUP_ELEMENT_SELECTION_MESSAGES = 1;
   BACKUP_ELEMENT_SELECTION_CONSENT = 2;
-  BACKUP_ELEMENT_SELECTION_EVENT = 3;
+  BACKUP_ELEMENT_SELECTION_EVENT = 3 [deprecated = true];
 }

--- a/proto/device_sync/event_backup.proto
+++ b/proto/device_sync/event_backup.proto
@@ -6,6 +6,7 @@ option java_package = "org.xmtp.proto.device_sync";
 
 // Proto representation of a client record save
 message EventSave {
+  option deprecated = true;
   int64 created_at_ns = 1;
   string event = 2;
   bytes details = 3;
@@ -15,6 +16,7 @@ message EventSave {
 }
 
 enum EventLevelSave {
+  option deprecated = true;
   EVENT_LEVEL_SAVE_UNSPECIFIED = 0;
   EVENT_LEVEL_SAVE_NONE = 1;
   EVENT_LEVEL_SAVE_SUCCESS = 2;


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Deprecate event backups by marking `BackupElement.element.event`, `BACKUP_ELEMENT_SELECTION_EVENT`, `EventSave`, and `EventLevelSave` as deprecated in proto definitions
Marks event-related fields and types as deprecated in device sync protos, including the `event` field in `BackupElement.element`, the `BACKUP_ELEMENT_SELECTION_EVENT` enum value, and the entire `EventSave` message and `EventLevelSave` enum. Changes are in [device_sync.proto](https://github.com/xmtp/proto/pull/314/files#diff-e00caf710d8ffb5e3377aebb8ff571df4ba566bf323790a523c73a905dba891e) and [event_backup.proto](https://github.com/xmtp/proto/pull/314/files#diff-964eea669c8319131ad0ec0677d424d8906e0dd669b65b4ea6f50ceae80e25d9).

#### 📍Where to Start
Start with the deprecation annotations in [device_sync.proto](https://github.com/xmtp/proto/pull/314/files#diff-e00caf710d8ffb5e3377aebb8ff571df4ba566bf323790a523c73a905dba891e), then review the message- and enum-level deprecations in [event_backup.proto](https://github.com/xmtp/proto/pull/314/files#diff-964eea669c8319131ad0ec0677d424d8906e0dd669b65b4ea6f50ceae80e25d9).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized f5fc12a.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->