### PR TITLE
Create a SendSendSyncArchive task

### DIFF
--- a/proto/mls/database/task.proto
+++ b/proto/mls/database/task.proto
@@ -18,5 +18,6 @@ message Task {
 
 message SendSyncArchive {
   xmtp.device_sync.BackupOptions options = 1;
-  optional string request_id = 2;
+  bytes originating_sync_group_id = 2;
+  optional string request_id = 3;
 }

--- a/proto/mls/database/task.proto
+++ b/proto/mls/database/task.proto
@@ -3,6 +3,7 @@
 syntax = "proto3";
 package xmtp.mls.database;
 
+import "device_sync/device_sync.proto";
 import "mls/message_contents/welcome_pointer.proto";
 
 option go_package = "github.com/xmtp/proto/v3/go/mls/database";
@@ -11,5 +12,11 @@ option java_package = "org.xmtp.proto.mls.database";
 message Task {
   oneof task {
     xmtp.mls.message_contents.WelcomePointer process_welcome_pointer = 1;
+    SendSyncArchive send_sync_archive = 2;
   }
+}
+
+message SendSyncArchive {
+  xmtp.device_sync.BackupOptions options = 1;
+  optional string request_id = 2;
 }

--- a/proto/mls/database/task.proto
+++ b/proto/mls/database/task.proto
@@ -18,6 +18,6 @@ message Task {
 
 message SendSyncArchive {
   xmtp.device_sync.BackupOptions options = 1;
-  bytes originating_sync_group_id = 2;
+  bytes sync_group_id = 2;
   optional string request_id = 3;
 }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add `xmtp.mls.database.Task.send_sync_archive` variant (tag 2) to support SendSyncArchive in [task.proto](https://github.com/xmtp/proto/pull/315/files#diff-aadcf88f97bf781801675028facb345056daf1bb521d7f74e0c0b9834596114f)
Add `SendSyncArchive` message with `xmtp.device_sync.BackupOptions options` (tag 1), `bytes sync_group_id` (tag 2), and optional `string request_id` (tag 3), and import `device_sync/device_sync.proto` in [task.proto](https://github.com/xmtp/proto/pull/315/files#diff-aadcf88f97bf781801675028facb345056daf1bb521d7f74e0c0b9834596114f).

#### 📍Where to Start
Start with the `xmtp.mls.database.Task` `oneof task` changes in [task.proto](https://github.com/xmtp/proto/pull/315/files#diff-aadcf88f97bf781801675028facb345056daf1bb521d7f74e0c0b9834596114f).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 0156980.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->