### PR TITLE
Switch Content Type to String

### DIFF
--- a/proto/device_sync/message_backup.proto
+++ b/proto/device_sync/message_backup.proto
@@ -14,13 +14,14 @@ message GroupMessageSave {
   bytes sender_installation_id = 6;
   string sender_inbox_id = 7;
   DeliveryStatusSave delivery_status = 8;
-  ContentTypeSave content_type = 9;
+  ContentTypeSave content_type_save = 9 [deprecated = true];
   int32 version_major = 10;
   int32 version_minor = 11;
   string authority_id = 12;
   optional bytes reference_id = 13;
   optional int64 sequence_id = 14;
   optional int64 originator_id = 15;
+  string content_type = 16;
 }
 
 // Group message kind
@@ -40,6 +41,7 @@ enum DeliveryStatusSave {
 
 // Group message content type
 enum ContentTypeSave {
+  option deprecated = true;
   CONTENT_TYPE_SAVE_UNSPECIFIED = 0;
   CONTENT_TYPE_SAVE_UNKNOWN = 1;
   CONTENT_TYPE_SAVE_TEXT = 2;


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Switch `GroupMessageSave.content_type` to string at tag 16 in [message_backup.proto](https://github.com/xmtp/proto/pull/316/files#diff-ec8b64076a258d0e47270c1ec4d7819e5335ea3418415b8cd467831f64b190fc) to replace the deprecated enum field at tag 9
Add `string` field `content_type` at tag 16 in `GroupMessageSave` and deprecate enum `ContentTypeSave`, renaming field 9 to `content_type_save` in [message_backup.proto](https://github.com/xmtp/proto/pull/316/files#diff-ec8b64076a258d0e47270c1ec4d7819e5335ea3418415b8cd467831f64b190fc).

#### 📍Where to Start
Start with the `GroupMessageSave` message definition in [message_backup.proto](https://github.com/xmtp/proto/pull/316/files#diff-ec8b64076a258d0e47270c1ec4d7819e5335ea3418415b8cd467831f64b190fc).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 8a0aafc.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->