### PR TITLE
Add server url to SendSyncArchive task

### DIFF
--- a/proto/mls/database/task.proto
+++ b/proto/mls/database/task.proto
@@ -20,4 +20,5 @@ message SendSyncArchive {
   xmtp.device_sync.BackupOptions options = 1;
   bytes sync_group_id = 2;
   optional string request_id = 3;
+  string server_url = 4;
 }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add `server_url` (tag 4) to `proto.mls.database.SendSyncArchive` to carry the server address for the task
Introduce a string field `server_url` with field number 4 in `SendSyncArchive` in [task.proto](https://github.com/xmtp/proto/pull/317/files#diff-aadcf88f97bf781801675028facb345056daf1bb521d7f74e0c0b9834596114f).

#### 📍Where to Start
Start with the `SendSyncArchive` message definition in [task.proto](https://github.com/xmtp/proto/pull/317/files#diff-aadcf88f97bf781801675028facb345056daf1bb521d7f74e0c0b9834596114f).

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 0c2bd4f. 1 file reviewed, 2 issues evaluated, 0 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues

</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->