### PR TITLE
add EditMessage

### DIFF
--- a/proto/mls/message_contents/content_types/edit_message.proto
+++ b/proto/mls/message_contents/content_types/edit_message.proto
@@ -1,0 +1,27 @@
+// edit_message.proto
+// This file defines the EditMessage message type and is associated with the following ContentTypeId:
+//
+// ContentTypeId {
+//     authority_id: "xmtp.org",
+//     type_id:      "editMessage",
+//     version_major: 1,
+//     version_minor: 0,
+// }
+//
+syntax = "proto3";
+
+package xmtp.mls.message_contents.content_types;
+
+import "mls/message_contents/content.proto";
+
+option go_package = "github.com/xmtp/proto/v3/go/mls/message_contents/content_types";
+option java_package = "org.xmtp.proto.mls.message_contents.content_types";
+
+// EditMessage message type
+message EditMessage {
+  // ID of the message to edit
+  string message_id = 1;
+
+  // The new content for the message
+  xmtp.mls.message_contents.EncodedContent edited_content = 2;
+}


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add `xmtp.mls.message_contents.content_types.EditMessage` to protocol definitions to support message edits in [edit_message.proto](https://github.com/xmtp/proto/pull/318/files#diff-e3b2be3a266a2084d9a2714a7c8d92c1140beb964beb98fae410c0e88ca1fb36)
Introduce a new proto message `EditMessage` with fields `string message_id = 1` and `xmtp.mls.message_contents.EncodedContent edited_content = 2` in [edit_message.proto](https://github.com/xmtp/proto/pull/318/files#diff-e3b2be3a266a2084d9a2714a7c8d92c1140beb964beb98fae410c0e88ca1fb36).

#### 📍Where to Start
Start with the `EditMessage` message definition in [edit_message.proto](https://github.com/xmtp/proto/pull/318/files#diff-e3b2be3a266a2084d9a2714a7c8d92c1140beb964beb98fae410c0e88ca1fb36).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized 989a479.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->