### PR TITLE
SubscribeTopics API

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version-file: ".node-version"
-          cache: 'npm'
+          cache: "npm"
       - run: npm ci
       - run: npm test
   kotlin:
@@ -26,8 +26,8 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
-          java-version: '11'
+          distribution: "temurin"
+          java-version: "11"
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
@@ -55,7 +55,7 @@ jobs:
           path: xmtpd
       - uses: actions/setup-go@v6
         with:
-          go-version: ">=1.25.0"
+          go-version: ">=1.26.0"
       - name: Install Go tools
         run: |
           cd xmtpd

--- a/proto/xmtpv4/message_api/message_api.proto
+++ b/proto/xmtpv4/message_api/message_api.proto
@@ -133,8 +133,6 @@ service ReplicationApi {
 
   rpc QueryEnvelopes(QueryEnvelopesRequest) returns (QueryEnvelopesResponse) {}
 
-  rpc QueryEnvelopes(QueryEnvelopesRequest) returns (QueryEnvelopesResponse) {}
-
   rpc PublishPayerEnvelopes(PublishPayerEnvelopesRequest) returns (PublishPayerEnvelopesResponse) {}
 
   rpc GetInboxIds(GetInboxIdsRequest) returns (GetInboxIdsResponse) {}

--- a/proto/xmtpv4/message_api/message_api.proto
+++ b/proto/xmtpv4/message_api/message_api.proto
@@ -24,6 +24,39 @@ message SubscribeEnvelopesRequest {
   EnvelopesQuery query = 1;
 }
 
+// Request to subscribe to a series of topics, with a separate cursor for each topic
+message SubscribeTopicsRequest {
+  message TopicFilter {
+    bytes topic = 1;
+    xmtp.xmtpv4.envelopes.Cursor last_seen = 2;
+  }
+
+  repeated TopicFilter filters = 1;
+}
+
+// Response to SubscribeTopics
+message SubscribeTopicsResponse {
+  enum SubscriptionStatus {
+    SUBSCRIPTION_STATUS_UNSPECIFIED = 0;
+    SUBSCRIPTION_STATUS_STARTED = 1;
+    SUBSCRIPTION_STATUS_CATCHUP_COMPLETE = 2;
+    SUBSCRIPTION_STATUS_WAITING = 3;
+  }
+
+  message StatusUpdate {
+    SubscriptionStatus status = 1;
+  }
+
+  message Envelopes {
+    repeated xmtp.xmtpv4.envelopes.OriginatorEnvelope envelopes = 1;
+  }
+
+  oneof response {
+    Envelopes envelopes = 1;
+    StatusUpdate status_update = 2;
+  }
+}
+
 // Streamed response for batch subscribe - can be multiple envelopes at once
 message SubscribeEnvelopesResponse {
   repeated xmtp.xmtpv4.envelopes.OriginatorEnvelope envelopes = 1;
@@ -91,46 +124,21 @@ message GetNewestEnvelopeResponse {
 }
 
 service ReplicationApi {
-  rpc SubscribeEnvelopes(SubscribeEnvelopesRequest) returns (stream SubscribeEnvelopesResponse) {
-    option (google.api.http) = {
-      post: "/mls/v2/subscribe-envelopes"
-      body: "*"
-    };
-  }
+  // This will be renamed to SubscribeOriginators
+  rpc SubscribeEnvelopes(SubscribeEnvelopesRequest) returns (stream SubscribeEnvelopesResponse) {}
 
-  rpc SubscribeAllEnvelopes(SubscribeAllEnvelopesRequest) returns (stream SubscribeEnvelopesResponse) {
-    option (google.api.http) = {
-      post: "/mls/v2/subscribe-all-envelopes"
-      body: "*"
-    };
-  }
+  rpc SubscribeAllEnvelopes(SubscribeAllEnvelopesRequest) returns (stream SubscribeEnvelopesResponse) {}
 
-  rpc QueryEnvelopes(QueryEnvelopesRequest) returns (QueryEnvelopesResponse) {
-    option (google.api.http) = {
-      post: "/mls/v2/query-envelopes"
-      body: "*"
-    };
-  }
+  rpc SubscribeTopics(SubscribeTopicsRequest) returns (stream SubscribeTopicsResponse) {}
 
-  rpc PublishPayerEnvelopes(PublishPayerEnvelopesRequest) returns (PublishPayerEnvelopesResponse) {
-    option (google.api.http) = {
-      post: "/mls/v2/publish-payer-envelopes"
-      body: "*"
-    };
-  }
+  rpc QueryEnvelopes(QueryEnvelopesRequest) returns (QueryEnvelopesResponse) {}
 
-  rpc GetInboxIds(GetInboxIdsRequest) returns (GetInboxIdsResponse) {
-    option (google.api.http) = {
-      post: "/mls/v2/get-inbox-ids"
-      body: "*"
-    };
-  }
+  rpc QueryEnvelopes(QueryEnvelopesRequest) returns (QueryEnvelopesResponse) {}
+
+  rpc PublishPayerEnvelopes(PublishPayerEnvelopesRequest) returns (PublishPayerEnvelopesResponse) {}
+
+  rpc GetInboxIds(GetInboxIdsRequest) returns (GetInboxIdsResponse) {}
 
   // Get the newest envelope for each topic
-  rpc GetNewestEnvelope(GetNewestEnvelopeRequest) returns (GetNewestEnvelopeResponse) {
-    option (google.api.http) = {
-      post: "/mls/v2/get-newest-envelope"
-      body: "*"
-    };
-  }
+  rpc GetNewestEnvelope(GetNewestEnvelopeRequest) returns (GetNewestEnvelopeResponse) {}
 }


### PR DESCRIPTION
### TL;DR

Added a new `SubscribeTopicEnvelopes` API endpoint.

### What changed?

- Added new `SubscribeTopicsRequest` and `SubscribeTopicsResponse` messages to support per-topic cursors
- Added a new `SubscribeTopics` RPC method to the `ReplicationApi` service
- Removed HTTP annotations from all RPC methods in the `ReplicationApi` service since they are unused on both the client and the server.

  
\## Future Changes

- We should rename the previous subscription endpoint `SubscribeOriginators` for clarity. Will handle that part separately.