### PR TITLE
Add `SubscribeAllEnvelopes` endpoint to the Replication API

### DIFF
--- a/proto/xmtpv4/message_api/message_api.proto
+++ b/proto/xmtpv4/message_api/message_api.proto
@@ -19,6 +19,7 @@ message EnvelopesQuery {
   xmtp.xmtpv4.envelopes.Cursor last_seen = 3;
 }
 
+// Batch subscribe to envelopes
 message SubscribeEnvelopesRequest {
   EnvelopesQuery query = 1;
 }
@@ -31,11 +32,6 @@ message SubscribeEnvelopesResponse {
 // Batch subscribe to all envelopes
 message SubscribeAllEnvelopesRequest {
   xmtp.xmtpv4.envelopes.Cursor last_seen = 1;
-}
-
-// Streamed response for batch subscribe - can be multiple envelopes at once
-message SubscribeAllEnvelopesResponse {
-  repeated xmtp.xmtpv4.envelopes.OriginatorEnvelope envelopes = 1;
 }
 
 // Query envelopes request
@@ -102,9 +98,8 @@ service ReplicationApi {
     };
   }
 
-  rpc SubscribeAllEnvelopes(SubscribeAllEnvelopesRequest) returns (stream SubscribeAllEnvelopesResponse) {
+  rpc SubscribeAllEnvelopes(SubscribeAllEnvelopesRequest) returns (stream SubscribeEnvelopesResponse) {
     option (google.api.http) = {
-      // TODO: Meaning here? Should vN be incremented?
       post: "/mls/v2/subscribe-all-envelopes"
       body: "*"
     };

--- a/proto/xmtpv4/message_api/message_api.proto
+++ b/proto/xmtpv4/message_api/message_api.proto
@@ -19,13 +19,22 @@ message EnvelopesQuery {
   xmtp.xmtpv4.envelopes.Cursor last_seen = 3;
 }
 
-// Batch subscribe to envelopes
 message SubscribeEnvelopesRequest {
   EnvelopesQuery query = 1;
 }
 
 // Streamed response for batch subscribe - can be multiple envelopes at once
 message SubscribeEnvelopesResponse {
+  repeated xmtp.xmtpv4.envelopes.OriginatorEnvelope envelopes = 1;
+}
+
+// Batch subscribe to all envelopes
+message SubscribeAllEnvelopesRequest {
+  xmtp.xmtpv4.envelopes.Cursor last_seen = 1;
+}
+
+// Streamed response for batch subscribe - can be multiple envelopes at once
+message SubscribeAllEnvelopesResponse {
   repeated xmtp.xmtpv4.envelopes.OriginatorEnvelope envelopes = 1;
 }
 
@@ -89,6 +98,14 @@ service ReplicationApi {
   rpc SubscribeEnvelopes(SubscribeEnvelopesRequest) returns (stream SubscribeEnvelopesResponse) {
     option (google.api.http) = {
       post: "/mls/v2/subscribe-envelopes"
+      body: "*"
+    };
+  }
+
+  rpc SubscribeAllEnvelopes(SubscribeAllEnvelopesRequest) returns (stream SubscribeAllEnvelopesResponse) {
+    option (google.api.http) = {
+      // TODO: Meaning here? Should vN be incremented?
+      post: "/mls/v2/subscribe-all-envelopes"
       body: "*"
     };
   }


### PR DESCRIPTION
This PR introduces a new endpoint to the Replication API specification, allowing subscription to all envelopes, with a cursor to optionally specify starting point.

This is a somewhat distinct version of `SubscribeEnvelopes`, which mandates that either topics or originators are specified  in the query filter.

This endpoint will be primarily (only) used by the notification server, and will have separate authorization and rate limit settings (details TBD).

Part of work on https://github.com/xmtp/example-notification-server-go/issues/61

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `SubscribeAllEnvelopes` RPC endpoint to the Replication API
> Adds a new `SubscribeAllEnvelopes` streaming RPC to the `ReplicationApi` service in [message_api.proto](https://github.com/xmtp/proto/pull/322/files#diff-72b1e00eb3b484952fa9e85e171a9ede388143ea0ff46a73314ceadc80ee17f0), exposed as `POST /mls/v2/subscribe-all-envelopes`. The new `SubscribeAllEnvelopesRequest` message accepts an optional `last_seen` cursor to support resumable streaming, and returns a stream of `SubscribeEnvelopesResponse` messages.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1565c0e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->