### PR TITLE
Proposals

### DIFF
--- a/proto/mls/database/intents.proto
+++ b/proto/mls/database/intents.proto
@@ -184,3 +184,35 @@ message PostCommitAction {
     SendWelcomes send_welcomes = 1;
   }
 }
+
+message ProposeMemberUpdateData {
+  message V1 {
+    // Not hex encoded
+    repeated bytes add_inbox_ids = 1;
+    repeated bytes remove_inbox_ids = 2;
+  }
+
+  oneof version {
+    V1 v1 = 1;
+  }
+}
+
+message ProposeGroupContextExtensionData {
+  message V1 {
+    bytes group_context_extension = 1;
+  }
+
+  oneof version {
+    V1 v1 = 1;
+  }
+}
+
+message CommitPendingProposalsData {
+  message V1 {
+    repeated bytes proposal_hashes = 1;
+  }
+
+  oneof version {
+    V1 v1 = 1;
+  }
+}

--- a/proto/mls/message_contents/proposal_support.proto
+++ b/proto/mls/message_contents/proposal_support.proto
@@ -1,0 +1,14 @@
+// Proposal support extension data
+syntax = "proto3";
+
+package xmtp.mls.message_contents;
+
+option go_package = "github.com/xmtp/proto/v3/go/mls/message_contents";
+option java_package = "org.xmtp.proto.mls.message.contents";
+
+// Extension data for proposal support in group context.
+// When present in the group context extensions, indicates the group
+// uses proposal-by-reference flow.
+message ProposalSupport {
+  uint32 version = 1;
+}


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add proposal-related proto message definitions for MLS group intents
- Adds `ProposeMemberUpdateData`, `ProposeGroupContextExtensionData`, and `CommitPendingProposalsData` messages to [intents.proto](https://github.com/xmtp/proto/pull/324/files#diff-6f0fe39046ec77adf0be4b95d56a75c664665c04f7c30965c66d2e5cd24319f0), each with a versioned V1 payload.
- Adds a new [proposal_support.proto](https://github.com/xmtp/proto/pull/324/files#diff-24fc926b29ae8f917a02bb37e9673f9d86f40d40940a6df765abd7a3a8d271ac) defining a `ProposalSupport` message with a `version` field in the `xmtp.mls.message_contents` package.
- The `ProposeMemberUpdateData.V1` carries `add_inbox_ids` and `remove_inbox_ids` fields; `CommitPendingProposalsData.V1` carries `proposal_hashes`.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized da01fe6.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->