### PR TITLE
Remove cursor support from `SubscribeAllEnvelopes`

### DIFF
--- a/proto/xmtpv4/message_api/message_api.proto
+++ b/proto/xmtpv4/message_api/message_api.proto
@@ -63,9 +63,7 @@ message SubscribeEnvelopesResponse {
 }
 
 // Batch subscribe to all envelopes
-message SubscribeAllEnvelopesRequest {
-  reserved 1;
-}
+message SubscribeAllEnvelopesRequest {}
 
 // Query envelopes request
 message QueryEnvelopesRequest {

--- a/proto/xmtpv4/message_api/message_api.proto
+++ b/proto/xmtpv4/message_api/message_api.proto
@@ -64,7 +64,7 @@ message SubscribeEnvelopesResponse {
 
 // Batch subscribe to all envelopes
 message SubscribeAllEnvelopesRequest {
-  xmtp.xmtpv4.envelopes.Cursor last_seen = 1;
+  reserved 1;
 }
 
 // Query envelopes request


### PR DESCRIPTION
As mentioned [here](https://github.com/xmtp/proto/issues/323) the amount of data one could unintentionally stream is too large, so we're removing cursor support for "stream all".

Technically correct would be to have the `reserve 1;` directive, but this change was not really released and no one really relies on it so no breaking changes should happen.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `last_seen` cursor field from `SubscribeAllEnvelopesRequest`
> Removes the `last_seen` cursor field from the `SubscribeAllEnvelopesRequest` proto message in [message_api.proto](https://github.com/xmtp/proto/pull/326/files#diff-72b1e00eb3b484952fa9e85e171a9ede388143ea0ff46a73314ceadc80ee17f0), leaving it empty. Risk: callers that set or read `last_seen` will break; serialized requests that previously included a cursor will now be empty.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 21efdc8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->