### PR TITLE
Phase 1: d14n service restructuring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,6 @@ Package.resolved
 # Kotlin
 kotlin/lib/src/main
 kotlin/bin
+
+# Agent plans
+docs/plans

--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -16,6 +16,8 @@ lint:
       - message_api/v1/message_api.proto
       - identity/api/v1/identity.proto
       - mls/api/v1/mls.proto
+      - xmtpv4/message_api/message_api.proto
+      - xmtpv4/message_api/query_api.proto
     RPC_RESPONSE_STANDARD_NAME:
       - message_api/v1/message_api.proto
       - identity/api/v1/identity.proto

--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -18,10 +18,15 @@ lint:
       - mls/api/v1/mls.proto
       - xmtpv4/message_api/message_api.proto
       - xmtpv4/message_api/query_api.proto
+      - xmtpv4/message_api/publish_api.proto
+      - xmtpv4/message_api/notification_api.proto
+      - xmtpv4/payer_api/payer_api.proto
+      - xmtpv4/gateway_api/gateway_api.proto
     RPC_RESPONSE_STANDARD_NAME:
       - message_api/v1/message_api.proto
       - identity/api/v1/identity.proto
       - mls/api/v1/mls.proto
+      - xmtpv4/message_api/notification_api.proto
   except:
     - PACKAGE_DIRECTORY_MATCH
     - PACKAGE_VERSION_SUFFIX

--- a/proto/xmtpv4/gateway_api/gateway_api.proto
+++ b/proto/xmtpv4/gateway_api/gateway_api.proto
@@ -1,0 +1,17 @@
+// Gateway API - Client to Gateway requests
+syntax = "proto3";
+
+package xmtp.xmtpv4.gateway_api;
+
+import "xmtpv4/payer_api/payer_api.proto";
+
+option go_package = "github.com/xmtp/proto/v3/go/xmtpv4/gateway_api";
+
+// Client -> Gateway. Replaces payer_api.PayerApi.
+service GatewayApi {
+  rpc PublishClientEnvelopes(xmtp.xmtpv4.payer_api.PublishClientEnvelopesRequest)
+      returns (xmtp.xmtpv4.payer_api.PublishClientEnvelopesResponse) {}
+
+  rpc GetNodes(xmtp.xmtpv4.payer_api.GetNodesRequest)
+      returns (xmtp.xmtpv4.payer_api.GetNodesResponse) {}
+}

--- a/proto/xmtpv4/message_api/message_api.proto
+++ b/proto/xmtpv4/message_api/message_api.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 
 package xmtp.xmtpv4.message_api;
 
-import "google/api/annotations.proto";
 import "identity/associations/association.proto";
 import "xmtpv4/envelopes/envelopes.proto";
 

--- a/proto/xmtpv4/message_api/message_api.proto
+++ b/proto/xmtpv4/message_api/message_api.proto
@@ -122,13 +122,23 @@ message GetNewestEnvelopeResponse {
 
 // Subscribe to envelopes from specific originator nodes
 message SubscribeOriginatorsRequest {
-  repeated uint32 originator_node_ids = 1;
-  xmtp.xmtpv4.envelopes.Cursor last_seen = 2;
+  message OriginatorFilter {
+    repeated uint32 originator_node_ids = 1;
+    xmtp.xmtpv4.envelopes.Cursor last_seen = 2;
+  }
+
+  OriginatorFilter filter = 1;
 }
 
 // Response for SubscribeOriginators
 message SubscribeOriginatorsResponse {
-  repeated xmtp.xmtpv4.envelopes.OriginatorEnvelope envelopes = 1;
+  message Envelopes {
+    repeated xmtp.xmtpv4.envelopes.OriginatorEnvelope envelopes = 1;
+  }
+
+  oneof response {
+    Envelopes envelopes = 1;
+  }
 }
 
 service ReplicationApi {

--- a/proto/xmtpv4/message_api/message_api.proto
+++ b/proto/xmtpv4/message_api/message_api.proto
@@ -121,20 +121,55 @@ message GetNewestEnvelopeResponse {
   repeated Response results = 1;
 }
 
+// Subscribe to envelopes from specific originator nodes
+message SubscribeOriginatorsRequest {
+  repeated uint32 originator_node_ids = 1;
+  xmtp.xmtpv4.envelopes.Cursor last_seen = 2;
+}
+
+// Response for SubscribeOriginators
+message SubscribeOriginatorsResponse {
+  repeated xmtp.xmtpv4.envelopes.OriginatorEnvelope envelopes = 1;
+}
+
 service ReplicationApi {
-  // This will be renamed to SubscribeOriginators
-  rpc SubscribeEnvelopes(SubscribeEnvelopesRequest) returns (stream SubscribeEnvelopesResponse) {}
+  // Node-to-node originator subscription
+  rpc SubscribeOriginators(SubscribeOriginatorsRequest)
+      returns (stream SubscribeOriginatorsResponse) {}
 
-  rpc SubscribeAllEnvelopes(SubscribeAllEnvelopesRequest) returns (stream SubscribeEnvelopesResponse) {}
+  // Deprecated: use SubscribeOriginators for node queries,
+  // QueryApi.SubscribeTopics for client queries
+  rpc SubscribeEnvelopes(SubscribeEnvelopesRequest)
+      returns (stream SubscribeEnvelopesResponse) {
+    option deprecated = true;
+  }
 
-  rpc SubscribeTopics(SubscribeTopicsRequest) returns (stream SubscribeTopicsResponse) {}
+  // Deprecated: moved to QueryApi
+  rpc SubscribeTopics(SubscribeTopicsRequest)
+      returns (stream SubscribeTopicsResponse) {
+    option deprecated = true;
+  }
 
-  rpc QueryEnvelopes(QueryEnvelopesRequest) returns (QueryEnvelopesResponse) {}
+  // Deprecated: moved to QueryApi
+  rpc QueryEnvelopes(QueryEnvelopesRequest)
+      returns (QueryEnvelopesResponse) {
+    option deprecated = true;
+  }
 
-  rpc PublishPayerEnvelopes(PublishPayerEnvelopesRequest) returns (PublishPayerEnvelopesResponse) {}
+  // Deprecated: moved to PublishApi
+  rpc PublishPayerEnvelopes(PublishPayerEnvelopesRequest)
+      returns (PublishPayerEnvelopesResponse) {
+    option deprecated = true;
+  }
 
-  rpc GetInboxIds(GetInboxIdsRequest) returns (GetInboxIdsResponse) {}
+  // Deprecated: moved to QueryApi
+  rpc GetInboxIds(GetInboxIdsRequest) returns (GetInboxIdsResponse) {
+    option deprecated = true;
+  }
 
-  // Get the newest envelope for each topic
-  rpc GetNewestEnvelope(GetNewestEnvelopeRequest) returns (GetNewestEnvelopeResponse) {}
+  // Deprecated: moved to QueryApi
+  rpc GetNewestEnvelope(GetNewestEnvelopeRequest)
+      returns (GetNewestEnvelopeResponse) {
+    option deprecated = true;
+  }
 }

--- a/proto/xmtpv4/message_api/misbehavior_api.proto
+++ b/proto/xmtpv4/message_api/misbehavior_api.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 
 package xmtp.xmtpv4.message_api;
 
-import "google/api/annotations.proto";
 import "identity/associations/signature.proto";
 import "xmtpv4/envelopes/envelopes.proto";
 import "xmtpv4/message_api/message_api.proto";
@@ -71,17 +70,7 @@ message QueryMisbehaviorReportsResponse {
 }
 
 service MisbehaviorApi {
-  rpc SubmitMisbehaviorReport(SubmitMisbehaviorReportRequest) returns (SubmitMisbehaviorReportResponse) {
-    option (google.api.http) = {
-      post: "/mls/v2/submit-misbehavior-report"
-      body: "*"
-    };
-  }
+  rpc SubmitMisbehaviorReport(SubmitMisbehaviorReportRequest) returns (SubmitMisbehaviorReportResponse) {}
 
-  rpc QueryMisbehaviorReports(QueryMisbehaviorReportsRequest) returns (QueryMisbehaviorReportsResponse) {
-    option (google.api.http) = {
-      post: "/mls/v2/query-misbehavior-reports"
-      body: "*"
-    };
-  }
+  rpc QueryMisbehaviorReports(QueryMisbehaviorReportsRequest) returns (QueryMisbehaviorReportsResponse) {}
 }

--- a/proto/xmtpv4/message_api/notification_api.proto
+++ b/proto/xmtpv4/message_api/notification_api.proto
@@ -1,0 +1,14 @@
+// Notification API - Full envelope stream for push notification servers
+syntax = "proto3";
+
+package xmtp.xmtpv4.message_api;
+
+import "xmtpv4/message_api/message_api.proto";
+
+option go_package = "github.com/xmtp/proto/v3/go/xmtpv4/message_api";
+
+// Full envelope stream for notification services.
+service NotificationApi {
+  rpc SubscribeAllEnvelopes(SubscribeAllEnvelopesRequest)
+      returns (stream SubscribeEnvelopesResponse) {}
+}

--- a/proto/xmtpv4/message_api/publish_api.proto
+++ b/proto/xmtpv4/message_api/publish_api.proto
@@ -1,0 +1,14 @@
+// Publish API - Gateway to Node publishing
+syntax = "proto3";
+
+package xmtp.xmtpv4.message_api;
+
+import "xmtpv4/message_api/message_api.proto";
+
+option go_package = "github.com/xmtp/proto/v3/go/xmtpv4/message_api";
+
+// Gateway -> Node.
+service PublishApi {
+  rpc PublishPayerEnvelopes(PublishPayerEnvelopesRequest)
+      returns (PublishPayerEnvelopesResponse) {}
+}

--- a/proto/xmtpv4/message_api/query_api.proto
+++ b/proto/xmtpv4/message_api/query_api.proto
@@ -1,0 +1,21 @@
+// Query API - Client to Node queries and subscriptions
+syntax = "proto3";
+
+package xmtp.xmtpv4.message_api;
+
+import "xmtpv4/message_api/message_api.proto";
+
+option go_package = "github.com/xmtp/proto/v3/go/xmtpv4/message_api";
+
+// Client -> Node. No auth token required.
+service QueryApi {
+  rpc QueryEnvelopes(QueryEnvelopesRequest) returns (QueryEnvelopesResponse) {}
+
+  rpc SubscribeTopics(SubscribeTopicsRequest)
+      returns (stream SubscribeTopicsResponse) {}
+
+  rpc GetInboxIds(GetInboxIdsRequest) returns (GetInboxIdsResponse) {}
+
+  rpc GetNewestEnvelope(GetNewestEnvelopeRequest)
+      returns (GetNewestEnvelopeResponse) {}
+}

--- a/proto/xmtpv4/metadata_api/metadata_api.proto
+++ b/proto/xmtpv4/metadata_api/metadata_api.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 
 package xmtp.xmtpv4.metadata_api;
 
-import "google/api/annotations.proto";
 import "xmtpv4/envelopes/envelopes.proto";
 
 option go_package = "github.com/xmtp/proto/v3/go/xmtpv4/metadata_api";
@@ -51,31 +50,11 @@ message GetPayerInfoResponse {
 
 // Metadata for distributed tracing, debugging and synchronization
 service MetadataApi {
-  rpc GetSyncCursor(GetSyncCursorRequest) returns (GetSyncCursorResponse) {
-    option (google.api.http) = {
-      post: "/mls/v2/metadata/get-sync-cursor"
-      body: "*"
-    };
-  }
+  rpc GetSyncCursor(GetSyncCursorRequest) returns (GetSyncCursorResponse) {}
 
-  rpc SubscribeSyncCursor(GetSyncCursorRequest) returns (stream GetSyncCursorResponse) {
-    option (google.api.http) = {
-      post: "/mls/v2/metadata/subscribe-sync-cursor"
-      body: "*"
-    };
-  }
+  rpc SubscribeSyncCursor(GetSyncCursorRequest) returns (stream GetSyncCursorResponse) {}
 
-  rpc GetVersion(GetVersionRequest) returns (GetVersionResponse) {
-    option (google.api.http) = {
-      post: "/mls/v2/metadata/version"
-      body: "*"
-    };
-  }
+  rpc GetVersion(GetVersionRequest) returns (GetVersionResponse) {}
 
-  rpc GetPayerInfo(GetPayerInfoRequest) returns (GetPayerInfoResponse) {
-    option (google.api.http) = {
-      post: "/mls/v2/metadata/get-payer-info"
-      body: "*"
-    };
-  }
+  rpc GetPayerInfo(GetPayerInfoRequest) returns (GetPayerInfoResponse) {}
 }

--- a/proto/xmtpv4/payer_api/payer_api.proto
+++ b/proto/xmtpv4/payer_api/payer_api.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 
 package xmtp.xmtpv4.payer_api;
 
-import "google/api/annotations.proto";
 import "xmtpv4/envelopes/envelopes.proto";
 
 option go_package = "github.com/xmtp/proto/v3/go/xmtpv4/payer_api";
@@ -22,20 +21,12 @@ message GetNodesResponse {
   map<uint32, string> nodes = 1;
 }
 
-// A narrowly scoped API for publishing messages through a payer
+// Deprecated: use gateway_api.GatewayApi
 service PayerApi {
-  // Publish envelope
-  rpc PublishClientEnvelopes(PublishClientEnvelopesRequest) returns (PublishClientEnvelopesResponse) {
-    option (google.api.http) = {
-      post: "/mls/v2/payer/publish-client-envelopes"
-      body: "*"
-    };
-  }
+  option deprecated = true;
 
-  rpc GetNodes(GetNodesRequest) returns (GetNodesResponse) {
-    option (google.api.http) = {
-      post: "/mls/v2/payer/get-nodes"
-      body: "*"
-    };
-  }
+  rpc PublishClientEnvelopes(PublishClientEnvelopesRequest)
+      returns (PublishClientEnvelopesResponse) {}
+
+  rpc GetNodes(GetNodesRequest) returns (GetNodesResponse) {}
 }


### PR DESCRIPTION
## Summary

Restructures the gRPC service definitions in `proto/xmtpv4/` to cleanly separate consumer concerns, as outlined in #327. This is Phase 1 — additive changes with deprecation markers. The only breaking change is moving the unused `SubscribeAllEnvelopes` RPC to a new `NotificationApi` service.

### New services

- **`QueryApi`** — Client-to-node queries and subscriptions (`QueryEnvelopes`, `SubscribeTopics`, `GetInboxIds`, `GetNewestEnvelope`)
- **`PublishApi`** — Gateway-to-node publishing (`PublishPayerEnvelopes`)
- **`NotificationApi`** — Full envelope stream for push notification servers (`SubscribeAllEnvelopes`)
- **`GatewayApi`** — Client-to-gateway requests, replacing `PayerApi` (`PublishClientEnvelopes`, `GetNodes`). Reuses message types from `payer_api`.

### ReplicationApi changes

- Added `SubscribeOriginators` with dedicated request/response types for node-to-node subscription
- Removed `SubscribeAllEnvelopes` (moved to `NotificationApi`, safe since unused)
- Deprecated all other RPCs with comments pointing to their new service locations

### Other changes

- Deprecated `PayerApi` service
- Removed `google/api/annotations` imports and HTTP option blocks from all xmtpv4 protos
- Updated `buf.yaml` lint ignores for shared request/response types during transition

### Verification

- `buf build` passes
- `buf breaking` passes (no breaking changes detected)
- No `google/api/annotations` remain in xmtpv4

Closes #327 (Phase 1)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restructure d14n service protos into dedicated API services
> - Splits `ReplicationApi` into focused services: [`QueryApi`](https://github.com/xmtp/proto/pull/328/files#diff-dc2f43fc49c5c3eef28f00945bb0eb327ceeca038f2ad3c1e885cf2daa3de2eb), [`PublishApi`](https://github.com/xmtp/proto/pull/328/files#diff-145de19a37e3db796426e5546cb88ada3287b657ad09faf074274b41ae49f75d), [`NotificationApi`](https://github.com/xmtp/proto/pull/328/files#diff-3d907898402fa31967b73036998d404a31f5c99e6edef2dc8e6b78c195ec0c20), and a new [`GatewayApi`](https://github.com/xmtp/proto/pull/328/files#diff-d1a1289bd36d823645a2be6792eddea49be46c44953f96f16ffae8c23ec8a202) for client-facing operations.
> - Adds `SubscribeOriginators` RPC to [`ReplicationApi`](https://github.com/xmtp/proto/pull/328/files#diff-72b1e00eb3b484952fa9e85e171a9ede388143ea0ff46a73314ceadc80ee17f0) with a new `SubscribeOriginatorsRequest` supporting per-originator node filters and a cursor; marks several existing RPCs as deprecated.
> - Removes HTTP/REST `google.api.annotations` bindings from [`MisbehaviorApi`](https://github.com/xmtp/proto/pull/328/files#diff-5d92b034c8fd86bd60c1ba75ca754b77ded71ef276621ffcf7e3bcbf238457f3), [`MetadataApi`](https://github.com/xmtp/proto/pull/328/files#diff-aa5cb3423d0bc7f4d081be0706d31911bd170adad5b444c9d5ef17024f2a2a2f), and [`PayerApi`](https://github.com/xmtp/proto/pull/328/files#diff-ff9c61c4661612b323bd2879119e0ea2ee2607686cbfa6a778158ee043e5a7a1), leaving only gRPC method signatures.
> - Marks `PayerApi` itself as deprecated; its `PublishClientEnvelopes` and `GetNodes` RPCs are now exposed via the new `GatewayApi`.
> - Behavioral Change: `SubscribeAllEnvelopes` is removed from `ReplicationApi` and moved to the new `NotificationApi` service.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fcad8b1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->