### PR TITLE
Add component metadata

### DIFF
--- a/proto/mls/message_contents/component_permissions.proto
+++ b/proto/mls/message_contents/component_permissions.proto
@@ -1,0 +1,52 @@
+// Component-level permission and metadata definitions for app data
+syntax = "proto3";
+
+package xmtp.mls.message_contents;
+
+import "mls/message_contents/group_permissions.proto";
+
+option go_package = "github.com/xmtp/proto/v3/go/mls/message_contents";
+option java_package = "org.xmtp.proto.mls.message.contents";
+
+// The data structure type of a component's value
+enum ComponentType {
+  COMPONENT_TYPE_UNSPECIFIED = 0;
+  // Opaque bytes, replaced atomically
+  COMPONENT_TYPE_BYTES = 1;
+  // A TlsMap<bytes, bytes> supporting key-level insert/update/delete via deltas
+  COMPONENT_TYPE_TLS_MAP_BYTES_BYTES = 2;
+  // A TlsMap<InboxId, bytes> supporting key-level insert/update/delete via deltas
+  COMPONENT_TYPE_TLS_MAP_INBOX_ID_BYTES = 3;
+  // A TlsSet<bytes> supporting insert/remove/remove-by-hash via deltas
+  COMPONENT_TYPE_SET_BYTES = 4;
+  // A TlsSet<InboxId> supporting insert/remove/remove-by-hash via deltas
+  COMPONENT_TYPE_SET_INBOX_ID = 5;
+}
+
+// Per-component permission policy with separate rules for insert, update,
+// and delete operations.
+//
+// Insert and update are separate because some components need different
+// permission levels for creating vs modifying entries. For example, group
+// membership allows any member to update (installations/sequence ID) but
+// only admins to insert (add a new member).
+message ComponentPermissions {
+  // Policy for inserting a new value (component does not yet exist)
+  MetadataPolicy insert_policy = 1;
+  // Policy for updating an existing value
+  MetadataPolicy update_policy = 2;
+  // Policy for deleting a value
+  MetadataPolicy delete_policy = 3;
+}
+
+// Metadata describing a component: its data type and permission policies.
+//
+// Stored as the value in the component registry (ComponentId 0x8000).
+// Each registered component has one of these describing what kind of data
+// it holds and who can insert, update, or delete it.
+message ComponentMetadata {
+  // Permission policies for this component
+  ComponentPermissions permissions = 1;
+  // The data structure type of the component's value
+  ComponentType component_type = 2;
+}


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add component metadata and permissions proto definitions for MLS message contents
Adds a new protobuf file [component_permissions.proto](https://github.com/xmtp/proto/pull/330/files#diff-590832bad99030e1c762b40f92cce716c7216aab051a365efd1b2a471c80a9ac) to the `xmtp.mls.message_contents` package defining three new types:
- `ComponentType` enum with six values covering bytes, TLS maps, and set types
- `ComponentPermissions` message with per-operation `MetadataPolicy` fields for insert, update, and delete
- `ComponentMetadata` message grouping a component's permissions and type

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized f0796a6.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->