### PR TITLE
Fix app data component type

### DIFF
--- a/proto/mls/message_contents/component_permissions.proto
+++ b/proto/mls/message_contents/component_permissions.proto
@@ -13,14 +13,16 @@ enum ComponentType {
   COMPONENT_TYPE_UNSPECIFIED = 0;
   // Opaque bytes, replaced atomically
   COMPONENT_TYPE_BYTES = 1;
+  // A utf-8 encoded string, replaced atomically
+  COMPONENT_TYPE_STRING = 2;
   // A TlsMap<bytes, bytes> supporting key-level insert/update/delete via deltas
-  COMPONENT_TYPE_TLS_MAP_BYTES_BYTES = 2;
+  COMPONENT_TYPE_TLS_MAP_BYTES_BYTES = 3;
   // A TlsMap<InboxId, bytes> supporting key-level insert/update/delete via deltas
-  COMPONENT_TYPE_TLS_MAP_INBOX_ID_BYTES = 3;
+  COMPONENT_TYPE_TLS_MAP_INBOX_ID_BYTES = 4;
   // A TlsSet<bytes> supporting insert/remove/remove-by-hash via deltas
-  COMPONENT_TYPE_SET_BYTES = 4;
+  COMPONENT_TYPE_TLS_SET_BYTES = 5;
   // A TlsSet<InboxId> supporting insert/remove/remove-by-hash via deltas
-  COMPONENT_TYPE_SET_INBOX_ID = 5;
+  COMPONENT_TYPE_TLS_SET_INBOX_ID = 6;
 }
 
 // Per-component permission policy with separate rules for insert, update,
@@ -45,8 +47,8 @@ message ComponentPermissions {
 // Each registered component has one of these describing what kind of data
 // it holds and who can insert, update, or delete it.
 message ComponentMetadata {
-  // Permission policies for this component
-  ComponentPermissions permissions = 1;
   // The data structure type of the component's value
-  ComponentType component_type = 2;
+  ComponentType component_type = 1;
+  // Permission policies for this component
+  ComponentPermissions permissions = 2;
 }


### PR DESCRIPTION
Fix app data component type to have consistent naming and to allow for strings to be enforced

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix field ordering and add `COMPONENT_TYPE_STRING` to `ComponentType` enum in component permissions proto
> - Adds `COMPONENT_TYPE_STRING` (value 2) to the `ComponentType` enum in [component_permissions.proto](https://github.com/xmtp/proto/pull/331/files#diff-590832bad99030e1c762b40f92cce716c7216aab051a365efd1b2a471c80a9ac) and shifts all subsequent enum values up by one.
> - Renames `COMPONENT_TYPE_SET_BYTES` and `COMPONENT_TYPE_SET_INBOX_ID` to `COMPONENT_TYPE_TLS_SET_BYTES` and `COMPONENT_TYPE_TLS_SET_INBOX_ID` respectively.
> - Swaps field numbers in `ComponentMetadata`: `component_type` moves to tag 1 and `permissions` moves to tag 2.
> - Risk: Both changes are wire-breaking — any existing serialized `ComponentMetadata` messages or encoded `ComponentType` enum values will decode incorrectly against the new schema.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized b5a88cc. 1 file reviewed, 2 issues evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->