### PR TITLE
Per inbox membership for app data

### DIFF
--- a/proto/mls/message_contents/group_membership.proto
+++ b/proto/mls/message_contents/group_membership.proto
@@ -13,3 +13,31 @@ message GroupMembership {
   // List of installations that failed to be added due to errors encountered during the evaluation process.
   repeated bytes failed_installations = 2;
 }
+
+// Per-member membership state stored inside the GROUP_MEMBERSHIP component
+// as a TlsMap<InboxId, bytes>. Keys are 32-byte inbox ids, values are the
+// encoded bytes of this message.
+message GroupMembershipEntry {
+  // V1 of the per-member membership state.
+  message V1 {
+    // Latest identity-update sequence id this client has applied for this
+    // member. Validator-checked at bootstrap against the pre-flip
+    // `GroupMembership.members[inbox_id]` value.
+    uint64 sequence_id = 1;
+    // Installation ids belonging to this member that we previously failed
+    // to add (expired key package, validation failure, etc.). Used to
+    // suppress retries on later membership updates.
+    //
+    // Sender-authoritative at migration: the migrator partitions the
+    // global `failed_installations` per inbox by walking identity-update
+    // history. Receivers accept these bytes as-is — the validator only
+    // checks `sequence_id`, so the blast radius of a bad partition is
+    // bounded to extra or silenced retries. Installations whose owning
+    // inbox can't be determined are dropped.
+    repeated bytes failed_installations = 2;
+  }
+
+  oneof version {
+    V1 v1 = 1;
+  }
+}


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add `GroupMembershipEntry` protobuf message for per-inbox membership state
Defines a new `GroupMembershipEntry` message in [group_membership.proto](https://github.com/xmtp/proto/pull/332/files#diff-b03a384c60c26a88abe0ee66081e2532df1851cb50a2f4bf471cd2b8a7816262) to store per-member inbox state. The message uses a versioned `oneof` with a `V1` variant holding `sequence_id` and `failed_installations` fields.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 07bc44c.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->