### PR TITLE
feat: external invite + ExternalCommitPolicy component + external_committer_permissions

### DIFF
--- a/proto/mls/message_contents/component_permissions.proto
+++ b/proto/mls/message_contents/component_permissions.proto
@@ -49,6 +49,14 @@ message ComponentPermissions {
 message ComponentMetadata {
   // The data structure type of the component's value
   ComponentType component_type = 1;
-  // Permission policies for this component
+  // Permission policies for this component, evaluated against regular
+  // (member-issued) commits.
   ComponentPermissions permissions = 2;
+  // Permission policies for this component, evaluated against MLS External
+  // Commits (RFC 9420 §12.4.3.2). Absent / unset is equivalent to all-Deny:
+  // external committers cannot touch this component. Each component opts in
+  // explicitly by setting this field. Combined with the EXTERNAL_COMMIT_POLICY
+  // master switch (`allow_external_commit`), this is the per-component declarative
+  // authorization for external-commit-driven joins.
+  ComponentPermissions external_committer_permissions = 3;
 }

--- a/proto/mls/message_contents/external_commit_policy.proto
+++ b/proto/mls/message_contents/external_commit_policy.proto
@@ -1,0 +1,139 @@
+// Group-wide external-commit policy component for the app-data registry.
+//
+// EXTERNAL_COMMIT_POLICY is a well-known component (registered with its
+// own ComponentId in the mid-range) that carries cross-cutting flags
+// governing whether and how new members may join the group via MLS
+// External Commits (RFC 9420 §12.4.3.2) — the QR-invite / link-invite
+// flow.
+//
+// This component is the master switch (defense-in-depth gate) for the
+// external-commit mechanism. Even when `allow_external_commit` is true,
+// the actual shape and effects of an external commit are bounded by:
+//
+//   1. RFC 9420 / libxmtp invariants enforced in the validator
+//      (exactly one ExternalInit, joiner credential binding on all Adds,
+//      no by-reference proposals, no SelfRemove, etc.).
+//   2. Per-component `external_committer_permissions` blocks declared on
+//      each touched component's `ComponentMetadata`.
+//
+// In other words: EXTERNAL_COMMIT_POLICY is the runtime-toggleable
+// master switch + time-window controls. `external_committer_permissions`
+// is the declarative, per-component surface that says *what* an external
+// committer may do once the master switch is on. Both must admit the
+// commit for it to be accepted.
+//
+// Toggling fields at runtime is an AppDataUpdate(EXTERNAL_COMMIT_POLICY)
+// proposal; the component's update policy (in its
+// `ComponentMetadata.permissions`) gates who can flip the bits
+// (super-admin-only by default).
+syntax = "proto3";
+
+package xmtp.mls.message_contents;
+
+option go_package = "github.com/xmtp/proto/v3/go/mls/message_contents";
+option java_package = "org.xmtp.proto.mls.message.contents";
+
+// v1 external-commit-policy payload.
+// Field-coupling invariants enforced by libxmtp when applying an
+// AppDataUpdate(EXTERNAL_COMMIT_POLICY) proposal:
+//
+//   * When `allow_external_commit` transitions to true: `symmetric_key`
+//     and `external_group_id` MUST be populated (non-empty, meeting
+//     their length requirements) in the same proposal. The two
+//     transitions are atomic — there is no window where the bit is on
+//     but the invite coordinates are unset.
+//
+//   * When `allow_external_commit` transitions to false (revoke):
+//     `symmetric_key` and `external_group_id` MUST be cleared (set to
+//     empty bytes) in the same proposal. Leaving stale coordinates in
+//     the group state after revoke would let a future re-enable
+//     accidentally revive a previously-distributed key.
+//
+//   * On re-enable (false → true after a prior revoke): the new
+//     `symmetric_key` MUST differ from every previously-used value for
+//     this group, and the new `external_group_id` SHOULD differ as
+//     well. Reusing a revoked key would re-validate every QR ever
+//     printed under that key, defeating the revocation. Admin clients
+//     are responsible for generating fresh material on each enable.
+message ExternalCommitPolicyV1 {
+  // Master switch for MLS External Commits adding new members.
+  // Required for the QR-invite flow. Defaults to false; admins
+  // (super-admin by default) opt in via
+  // AppDataUpdate(EXTERNAL_COMMIT_POLICY).
+  //
+  // See the field-coupling invariants in the message-level comment
+  // above: enabling MUST populate symmetric_key + external_group_id;
+  // revoking (true → false) MUST clear them.
+  bool allow_external_commit = 1;
+  // Wall-clock auto-disable timestamp (ns since UNIX epoch).
+  // 0 = no automatic expiry. After this timestamp the validator
+  // rejects all external commits regardless of `allow_external_commit`.
+  // Lets admins issue time-bounded invite campaigns without having to
+  // come back and flip the bit manually.
+  uint64 expires_at_ns = 2;
+  // Maximum staleness of the GroupInfo referenced by an external
+  // commit, in nanoseconds since GroupInfo export. 0 = no staleness
+  // limit. External commits whose referenced GroupInfo was exported
+  // more than `expire_in_ns` ago are rejected. Narrows the replay
+  // window for stolen-blob attacks and forces re-export frequency.
+  uint64 expire_in_ns = 3;
+  // 32-byte ChaCha20Poly1305 key used to wrap the EncryptedGroupInfoBlob
+  // for the currently-active invite. Carried in the group state so any
+  // member (especially a just-joined external committer) can re-export
+  // GroupInfo and re-upload a refreshed blob under the same key after a
+  // join — without this, a printed QR / link would die the moment the
+  // issuing admin went offline.
+  //
+  // The QR carries the same key bytes. Rotation = admin sets a new value
+  // here in a single AppDataUpdate(EXTERNAL_COMMIT_POLICY) proposal AND
+  // issues a new QR carrying the matching key; old QR holders' keys no
+  // longer decrypt blobs the service serves under the rotated slot.
+  //
+  // Length MUST be exactly 32 bytes when populated. Empty (zero-length)
+  // means no active invite — and MUST coincide with
+  // `allow_external_commit == false` (see the field-coupling invariants
+  // at the top of this message). Revoking the invite MUST clear this
+  // field; re-enabling MUST populate it with a freshly-generated value
+  // distinct from any previously-used key for this group.
+  //
+  // Note: the service_pointer (where the blob lives) is intentionally
+  // NOT stored in the group. It is per-QR application-defined opaque
+  // bytes; different invites for the same group may point at different
+  // services. Joiners use the service_pointer from the QR they scanned.
+  bytes symmetric_key = 4;
+  // Identifier for the service slot holding the active invite's
+  // encrypted blob. Application-defined opaque bytes (UUID, snowflake,
+  // short slot key, etc.); decoupled from the MLS group_id. Admins
+  // MAY rotate the symmetric_key while keeping this stable (overwrite
+  // the same slot on the service) or change both together (new slot,
+  // leaves the old slot orphaned for application-side GC).
+  //
+  // The QR carries the same value. The joiner verifies that the QR's
+  // `external_group_id` equals this field after joining, as
+  // defense-in-depth against a stale or swapped QR. Mismatch indicates
+  // the admin rotated to a new slot after the QR was minted; the
+  // joining client SHOULD treat the just-published commit as orphaned
+  // (it validates fine, but the refreshed blob the joiner would upload
+  // to the old slot will not be reachable by holders of the new QR).
+  //
+  // MUST be at least 4 bytes when populated (collision-avoidance floor
+  // for tiny services). RECOMMENDED: 16 random bytes when no
+  // application-specific scheme is in use. Empty (zero-length) means
+  // no active invite — and MUST coincide with
+  // `allow_external_commit == false` (see the field-coupling
+  // invariants at the top of this message). Revoking the invite MUST
+  // clear this field; re-enabling SHOULD use a freshly-generated value
+  // (reusing a prior `external_group_id` is permitted only when the
+  // admin intends to overwrite the old service slot — typically the
+  // admin generates a new value to leave the prior slot orphaned).
+  bytes external_group_id = 5;
+}
+
+// Versioned envelope. New variants are added as new oneof variants;
+// readers that don't recognize a variant treat the policy as default
+// (all fields zero) per the standard unknown-variant tolerance rules.
+message ExternalCommitPolicyEntry {
+  oneof version {
+    ExternalCommitPolicyV1 v1 = 1;
+  }
+}

--- a/proto/mls/message_contents/external_invite.proto
+++ b/proto/mls/message_contents/external_invite.proto
@@ -1,0 +1,112 @@
+// External invite payloads used for QR-code or link-based joining via MLS external commits
+syntax = "proto3";
+
+package xmtp.mls.message_contents;
+
+option go_package = "github.com/xmtp/proto/v3/go/mls/message_contents";
+option java_package = "org.xmtp.proto.mls.message.contents";
+
+// v1 shape of the shareable invite blob for QR-code or link-based joining
+// of an XMTP group via an MLS external commit.
+message ExternalInvitePayloadV1 {
+  // Application-defined opaque bytes identifying the service location.
+  bytes service_pointer = 1;
+  // Identifier for the service slot holding the encrypted blob. Format
+  // is application-defined (UUID, snowflake, short slot key, etc.) and
+  // opaque to libxmtp; the only constraint is that the value is unique
+  // within the chosen service. Decoupled from the MLS group_id —
+  // rotation may keep this stable (overwrite the same slot) or change
+  // it (new slot on the service); the admin chooses per invite.
+  //
+  // MUST be at least 4 bytes (collision-avoidance floor for tiny
+  // services). RECOMMENDED: 16 random bytes when no application-
+  // specific scheme is in use. Maximum length is not capped by the
+  // protocol; applications should bound it to fit their QR / link
+  // transport.
+  //
+  // After joining, the joiner verifies this matches
+  // `EXTERNAL_COMMIT_POLICY.external_group_id` in the group state as
+  // defense-in-depth against a stale or swapped QR.
+  bytes external_group_id = 2;
+  // 32 bytes; ChaCha20Poly1305 key used to wrap the GroupInfo. Matches
+  // `EXTERNAL_COMMIT_POLICY.symmetric_key` in the group state.
+  bytes symmetric_key = 3;
+}
+
+// Versioned envelope for the shareable invite blob. The application embeds
+// the serialized bytes in whatever transport it prefers (hex, base64, raw
+// QR, NFC, etc.) and stores the corresponding EncryptedGroupInfoBlob on an
+// external service keyed by the v1 payload's `external_group_id`.
+//
+// New wire-format variants are added as new oneof entries; readers that
+// don't recognize a variant treat the invite as unparseable and fail
+// closed (no implicit downgrade).
+message ExternalInvitePayload {
+  oneof version {
+    ExternalInvitePayloadV1 v1 = 1;
+  }
+}
+
+// v1 shape of the encrypted-GroupInfo envelope.
+//
+// `epoch` and `group_state_hash` are plaintext metadata serving two
+// distinct purposes:
+//
+//   * `epoch` provides a total ordering on uploads. The service accepts
+//     an upload iff `upload.epoch > current.epoch` (strictly newer);
+//     lower-epoch uploads are stale and rejected outright.
+//
+//   * `group_state_hash` is a consistency check at a single epoch. MLS
+//     is deterministic — every member that applies the same commit
+//     derives identical group state — so two correct uploads at the
+//     same epoch MUST carry the same hash. When `upload.epoch ==
+//     current.epoch`: equal hashes mean an idempotent re-upload (no-op
+//     or duplicate-reject); different hashes mean the uploaders are on
+//     forked views of the group and the service must refuse to pick a
+//     winner.
+//
+// The joiner additionally verifies on download that the blob's `epoch`
+// and `group_state_hash` match the decrypted GroupInfo before
+// attempting to join — closes the "malicious service swapped
+// ciphertext" gap.
+message EncryptedGroupInfoBlobV1 {
+  // 12 bytes; ChaCha20Poly1305 nonce specific to this ciphertext.
+  bytes nonce = 1;
+  // wrap_payload_symmetric output: AEAD ciphertext over the serialized
+  // MlsMessageOut(GroupInfo).
+  bytes ciphertext = 2;
+  // MLS group epoch of the wrapped GroupInfo. Plaintext; the service
+  // totally orders uploads by this value — strictly-newer wins, stale
+  // is rejected. Joiner verifies against the decrypted GroupInfo
+  // before joining.
+  uint64 epoch = 3;
+  // Tree-hash (or equivalent group-state digest) of the wrapped
+  // GroupInfo. Plaintext; the service uses this only at equal epochs
+  // to detect forks (same epoch + differing hash = forked uploaders).
+  // Not used for ordering. Joiner verifies against the decrypted
+  // GroupInfo before joining.
+  bytes group_state_hash = 4;
+  // Wall-clock expiry of this blob, in nanoseconds since UNIX epoch.
+  // 0 means no expiry. The service uses this as a TTL hint and MAY
+  // garbage-collect blobs past their `expires_at_ns` autonomously.
+  // The joining client also enforces this — refuses to join from an
+  // expired blob even if the service is still serving it. Admin
+  // bounds the campaign by setting this at upload time; extending an
+  // invite is a re-upload with a later value.
+  uint64 expires_at_ns = 5;
+}
+
+// Versioned envelope wrapping a single GroupInfo TLS-serialized bytes
+// under an AEAD scheme (ChaCha20Poly1305 in v1) with a fresh nonce per
+// re-encryption. Stored on the external service and replaced by joiners
+// (with a fresh nonce) after each successful join.
+//
+// New variants represent breaking wire-format changes (different AEAD,
+// different metadata layout). Readers that don't recognize a variant
+// fail closed — the joiner cannot attempt MLS state transitions against
+// a blob it can't validate.
+message EncryptedGroupInfoBlob {
+  oneof version {
+    EncryptedGroupInfoBlobV1 v1 = 1;
+  }
+}


### PR DESCRIPTION
## Summary

QR-invite wire format + new EXTERNAL_COMMIT_POLICY well-known component + per-component external-committer policy block, all in `xmtp.mls.message_contents`. Sits on top of #333 (the generic AppData intent proto).

**Three additions:**

1. **`ExternalInvitePayload` + `EncryptedGroupInfoBlob`** (`external_invite.proto`) — wire format for QR-code / link-based joining via MLS External Commits. Blob carries plaintext `epoch` (uint64) and `group_state_hash` (bytes) so the external invite-storage service can do monotonic ordering and fork detection without seeing plaintext GroupInfo.

2. **`ExternalCommitPolicyV1` + `ExternalCommitPolicyEntry`** (`external_commit_policy.proto`) — new well-known component carrying:
   - `allow_external_commit: bool` — defense-in-depth master switch
   - `expires_at_ns: uint64` — wall-clock auto-disable for time-bounded invite campaigns
   - `expire_in_ns: uint64` — max staleness of the GroupInfo referenced by an external commit

3. **`external_committer_permissions: ComponentPermissions`** field added to `ComponentMetadata` — sibling of the existing `permissions` block. Governs per-component what external committers may do. Absent = all-Deny.

Together these form the two-layer authorization model for the QR-invite flow: a runtime-toggleable master switch + per-component declarative external-committer capabilities. See libxmtp PR #3666 for the consuming code.

## Test plan

- [x] Pinned in libxmtp at SHA `424fdd061d41bdd7e81185735329de414dfd8e4c`.
- [x] libxmtp regen succeeds.
- [x] Helper round-trip tests pass in libxmtp PR #3666.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add external invite, `ExternalCommitPolicy`, and `external_committer_permissions` protobuf definitions
> - Adds [`external_invite.proto`](https://github.com/xmtp/proto/pull/334/files#diff-4e2060058cd7409c1d28d62192d973c0a5fa623a25052eb73237c8423f87d59a) defining `ExternalInvitePayloadV1` (service pointer, external group ID, symmetric key) and `EncryptedGroupInfoBlobV1` (nonce, ciphertext, epoch, state hash, expiry) with versioned envelope wrappers for both.
> - Adds [`external_commit_policy.proto`](https://github.com/xmtp/proto/pull/334/files#diff-24edff2193fdbf16b43848059b2704488ba18987dd7d3f591682edbd8494fc1f) defining `ExternalCommitPolicyV1` with fields for allow/deny, expiry, and symmetric key, plus a versioned `ExternalCommitPolicyEntry` envelope.
> - Adds `external_committer_permissions` (field 3) to `ComponentMetadata` in [`component_permissions.proto`](https://github.com/xmtp/proto/pull/334/files#diff-590832bad99030e1c762b40f92cce716c7216aab051a365efd1b2a471c80a9ac), scoped to MLS External Commits, while clarifying that the existing `permissions` field applies only to regular member-issued commits.
> - All new messages use versioned oneof wrappers for forward-compatible parsing; existing serialized messages are unaffected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2bef315.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->