### PR TITLE
feat(mls/database): add ProcessPendingSelfRemove Task variant

### DIFF
--- a/proto/mls/database/task.proto
+++ b/proto/mls/database/task.proto
@@ -13,6 +13,7 @@ message Task {
   oneof task {
     xmtp.mls.message_contents.WelcomePointer process_welcome_pointer = 1;
     SendSyncArchive send_sync_archive = 2;
+    ProcessPendingSelfRemove process_pending_self_remove = 3;
   }
 }
 
@@ -21,4 +22,13 @@ message SendSyncArchive {
   bytes sync_group_id = 2;
   optional string pin = 3;
   string server_url = 4;
+}
+
+// Durable TaskRunner intent: process a group's pending self-remove requests
+// (build the MLS RemoveProposal/Commit to evict members who sent a LeaveRequest,
+// then clean up the pending-remove list). Enqueued in the same DB transaction as
+// the pending_remove row so it survives restart; runs on the TaskRunner with
+// retry/backoff. group_id is the target conversation.
+message ProcessPendingSelfRemove {
+  bytes group_id = 1;
 }


### PR DESCRIPTION
Adds a third `Task` oneof variant, `ProcessPendingSelfRemove { group_id }` (tag 3), to `proto/mls/database/task.proto`.

## Why
libxmtp is converting the poll-based `PendingSelfRemoveWorker` into a durable, event-driven task on the existing `TaskRunner`. When a `LeaveRequest` is received, libxmtp records a `pending_remove` row; a super-admin client must then build the MLS RemoveProposal/Commit to actually evict the member. Folding this into the `TaskRunner` gives it persistence-across-restart, retry, and exponential backoff for free — but requires a `Task` variant to represent the work.

This is the upstream-proto prerequisite for the libxmtp stacked PR (`insipx/event-driven-self-remove`). Once this merges, libxmtp regenerates via `dev/gen_protos.sh` and consumes tag 3.

## Compatibility
Additive only — new oneof field with a fresh tag (3). No existing field changed; backward compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `ProcessPendingSelfRemove` task variant to MLS database proto
> Adds a new `ProcessPendingSelfRemove` message and a corresponding `process_pending_self_remove` oneof variant (field 3) to the `Task` message in [task.proto](https://github.com/xmtp/proto/pull/335/files#diff-aadcf88f97bf781801675028facb345056daf1bb521d7f74e0c0b9834596114f). The new message carries a single `group_id` bytes field to identify the group for which a pending self-remove should be processed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cd67a68.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->