### PR TITLE
add TaskRunner scheduling protos: PullInDeadline, KpRotation, KpDeletion

### DIFF
--- a/proto/mls/database/task.proto
+++ b/proto/mls/database/task.proto
@@ -14,8 +14,28 @@ message Task {
     xmtp.mls.message_contents.WelcomePointer process_welcome_pointer = 1;
     SendSyncArchive send_sync_archive = 2;
     ProcessPendingSelfRemove process_pending_self_remove = 3;
+    PullInDeadline pull_in_deadline = 4;
+    KpRotation kp_rotation = 5;
+    KpDeletion kp_deletion = 6;
   }
 }
+
+// Lower a target task's next-attempt deadline so it runs sooner. One-shot:
+// applied by the TaskWorker, then deleted.
+message PullInDeadline {
+  // The UNIQUE data_hash identifying the target task row.
+  bytes target_data_hash = 1;
+  // Target's next_attempt_at_ns is set to MIN(current, this).
+  int64 not_later_than_ns = 2;
+}
+
+// Recurring singleton: rotate + upload a fresh key package when the identity's
+// rotation deadline is due. Empty payload => stable data_hash for pull-ins.
+message KpRotation {}
+
+// Recurring singleton: delete superseded local key-package material whose
+// delete_at_ns has passed. Empty payload => stable data_hash for pull-ins.
+message KpDeletion {}
 
 message SendSyncArchive {
   xmtp.device_sync.ArchiveOptions options = 1;


### PR DESCRIPTION
Adds three task variants to `xmtp.mls.database.Task` for generic recurring-task support in libxmtp's TaskRunner:

- **`PullInDeadline` (tag 4)** — generic one-shot "run a task sooner" primitive: lowers a target task row's `next_attempt_at_ns` to `MIN(current, not_later_than_ns)`, targeting the row by its unique `data_hash`.
- **`KpRotation` (tag 5)** — recurring singleton: rotate + upload a fresh key package when the identity's rotation deadline is due.
- **`KpDeletion` (tag 6)** — recurring singleton: delete superseded local key-package material past its `delete_at_ns`.

Empty payloads on the two singletons give each a stable `data_hash` so pull-ins can target them.

Replaces this PR's earlier single `KpMaintenance` message: rotation and deletion are now independent tasks (different deadlines, cadences, and latency tolerances), and the nudge mechanism is generic rather than KP-specific.

Consumed by xmtp/libxmtp#3805 + xmtp/libxmtp#3806 (generic layer, vendored regen ahead of pin) and a follow-up KP-consumer stack; libxmtp's `proto_version` gets bumped to this PR's merge SHA once landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `PullInDeadline`, `KpRotation`, and `KpDeletion` task variants to TaskRunner scheduling protos
> Extends the `Task` oneof in [task.proto](https://github.com/xmtp/proto/pull/339/files#diff-aadcf88f97bf781801675028facb345056daf1bb521d7f74e0c0b9834596114f) with three new variants (field numbers 4–6).
>
> - `PullInDeadline` carries a `target_data_hash` and a `not_later_than_ns` timestamp for deadline-based scheduling
> - `KpRotation` and `KpDeletion` are empty messages representing recurring singleton key package operations
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f9f0a35.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->