### PR TITLE
Add mutate_id wave tag to Subscribe delivery frames

### DIFF
--- a/proto/mls/api/v1/mls.proto
+++ b/proto/mls/api/v1/mls.proto
@@ -451,19 +451,25 @@ message SubscribeRequest {
     // adopted via the capabilities advertised on Started.
     message Mutate {
       repeated Subscription adds = 1; // begin delivering these topics
-      repeated bytes removes = 2; // topics to stop delivering
+      repeated bytes removes = 2; // stop delivering; clears the topic's cursor floor so a re-add replays
 
-      // Catch this Mutate's adds up to the live edge — history, TopicsLive
-      // markers, and the wave's CatchupComplete — but do NOT register them
-      // for live delivery. The markers then mean "you have everything as of
-      // now". Combined with half-closing the request stream, this is the
+      // Catch this Mutate's adds up — history, TopicsLive markers, and the
+      // wave's CatchupComplete — but do NOT register them for live delivery.
+      // The markers then mean "you have everything as of the wave's start";
+      // later messages arrive on no lane of this stream. Combined with
+      // half-closing the request stream, this is the
       // bounded catch-up ("sync") mode: the server finishes the wave and then
       // closes the stream itself. Removals in the Mutate are unaffected.
       bool history_only = 3;
 
-      // Client-chosen correlation id, echoed on this wave's CatchupComplete
-      // so completions are attributable when waves overlap. SHOULD be unique
-      // per stream; 0 = no correlation requested (still echoed as 0).
+      // Client-chosen correlation id: echoed on this wave's CatchupComplete,
+      // and stamped on every delivery frame of the wave's catch-up replay
+      // (Messages.mutate_id). MUST be nonzero when adds are present (0 is the
+      // live tag), and MUST NOT match the mutate_id of a wave still in flight
+      // on the stream (an in-flight collision would make two waves' frames and
+      // completions indistinguishable) — either violation fails the stream
+      // with INVALID_ARGUMENT. SHOULD be unique per stream so completed waves
+      // stay attributable too.
       uint64 mutate_id = 4;
 
       // A topic to subscribe, with the cursor to resume from.
@@ -492,15 +498,22 @@ message SubscribeResponse {
       Started started = 2; // sent once, immediately on open, before any catch-up
       Ping ping = 3; // idle liveness challenge; receiver MUST answer with Pong
       Pong pong = 4; // answer to a client Ping
-      TopicsLive topics_live = 5; // these topics just crossed from catch-up to live
-      CatchupComplete catchup_complete = 6; // a Mutate's adds are fully delivered
+      TopicsLive topics_live = 5; // no more replay for these topics; live begins after CatchupComplete
+      CatchupComplete catchup_complete = 6; // acks a Mutate; wave completion if it started one
     }
 
     // A batch of new messages; group and welcome messages share the stream,
-    // depending on which subscriptions are active.
+    // depending on which subscriptions are active. A frame belongs to exactly
+    // one catch-up wave or to live — the server never mixes lanes, or two
+    // waves, in one frame — and each lane is delivered in ascending id order
+    // per message kind (live: across all live topics on the stream; a wave:
+    // across the wave's topics, one merged cursor-ordered pass).
     message Messages {
       repeated GroupMessage group_messages = 1;
       repeated WelcomeMessage welcome_messages = 2;
+      // The catch-up wave that produced this frame: the Mutate's mutate_id
+      // for wave replay, 0 for live tail.
+      uint64 mutate_id = 3;
     }
 
     // The first frame on every stream.
@@ -515,20 +528,25 @@ message SubscribeResponse {
       repeated Capability capabilities = 2;
     }
 
-    // Sent once per Mutate that adds subscriptions (a catch-up "wave"), after
-    // the wave's last TopicsLive: everything the Mutate asked for is delivered.
+    // Sent once per Mutate: at wave completion (after the wave's last
+    // TopicsLive) for a Mutate that started a catch-up "wave", immediately for
+    // one that did not (nothing added — removes-only or empty — or every add
+    // a no-op). Also the catch-up
+    // seam: live frames (mutate_id 0) for the wave's topics begin only after
+    // this frame.
     message CatchupComplete {
-      uint64 mutate_id = 1; // echoes the Mutate that started this wave (0 if none given)
+      uint64 mutate_id = 1; // echoes the Mutate; 0 only if a waveless Mutate carried 0
     }
 
     // Emitted when topics finish catch-up, AFTER the last history frame for
-    // them — including any live messages that queued up behind the catch-up,
-    // which were equally historical from the client's perspective — so every
-    // later frame for a listed topic is live tail. Informational only: delivery
+    // them — including messages that arrived mid-wave and were folded into it,
+    // which were equally historical from the client's perspective — so no
+    // further replay for a listed topic follows; its live (mutate_id 0) frames
+    // begin after the wave's CatchupComplete. Informational only: delivery
     // correctness (no duplicates, no gaps) never depends on it. Re-adding a
     // topic re-runs catch-up and re-emits it; receivers treat it idempotently.
     message TopicsLive {
-      repeated bytes topics = 1; // kind-prefixed topics now tailing live
+      repeated bytes topics = 1; // kind-prefixed topics done replaying
     }
 
     // Optional per-stream protocol features (none defined yet; future

--- a/proto/xmtpv4/message_api/message_api.proto
+++ b/proto/xmtpv4/message_api/message_api.proto
@@ -95,19 +95,25 @@ message SubscribeRequest {
     // whose kind the node does not serve fails the stream with INVALID_ARGUMENT.
     message Mutate {
       repeated Subscription adds = 1; // begin delivering these topics
-      repeated bytes removes = 2; // topics to stop delivering
+      repeated bytes removes = 2; // stop delivering; clears the topic's cursor floor so a re-add replays
 
-      // Catch this Mutate's adds up to the live edge — history, TopicsLive
-      // markers, and the wave's CatchupComplete — but do NOT register them for
-      // live delivery. The markers then mean "you have everything as of now".
-      // Combined with half-closing the request stream, this is the bounded
-      // catch-up ("sync") mode: the node finishes the wave then closes the
-      // stream itself. Removals in the Mutate are unaffected.
+      // Catch this Mutate's adds up — history, TopicsLive markers, and the
+      // wave's CatchupComplete — but do NOT register them for live delivery.
+      // The markers then mean "you have everything as of the wave's start";
+      // later envelopes arrive on no lane of this stream. Combined with
+      // half-closing the request stream, this is the bounded catch-up ("sync")
+      // mode: the node finishes the wave then closes the stream itself.
+      // Removals in the Mutate are unaffected.
       bool history_only = 3;
 
-      // Client-chosen correlation id, echoed on this wave's CatchupComplete so
-      // completions are attributable when waves overlap. SHOULD be unique per
-      // stream; 0 = no correlation requested (still echoed as 0).
+      // Client-chosen correlation id: echoed on this wave's CatchupComplete,
+      // and stamped on every delivery frame of the wave's catch-up replay
+      // (Envelopes.mutate_id). MUST be nonzero when adds are present (0 is the
+      // live tag), and MUST NOT match the mutate_id of a wave still in flight
+      // on the stream (an in-flight collision would make two waves' frames and
+      // completions indistinguishable) — either violation fails the stream
+      // with INVALID_ARGUMENT. SHOULD be unique per stream so completed waves
+      // stay attributable too.
       uint64 mutate_id = 4;
 
       // A topic to subscribe, with the vector cursor to resume from.
@@ -135,14 +141,21 @@ message SubscribeResponse {
       Started started = 2; // sent once, immediately on open, before any catch-up
       Ping ping = 3; // idle liveness challenge; receiver MUST answer with Pong
       Pong pong = 4; // answer to a client Ping
-      TopicsLive topics_live = 5; // these topics just crossed from catch-up to live
-      CatchupComplete catchup_complete = 6; // a Mutate's adds are fully delivered
+      TopicsLive topics_live = 5; // no more replay for these topics; live begins after CatchupComplete
+      CatchupComplete catchup_complete = 6; // acks a Mutate; wave completion if it started one
     }
 
     // A batch of envelopes across the active subscriptions; the client demuxes
-    // by each envelope's target topic.
+    // by each envelope's target topic. A frame belongs to exactly one catch-up
+    // wave or to live — the node never mixes lanes, or two waves, in one frame
+    // — and each lane delivers every originator's envelopes in ascending
+    // originator_sequence_id (live: across all live topics on the stream; a
+    // wave: across the wave's topics).
     message Envelopes {
       repeated xmtp.xmtpv4.envelopes.OriginatorEnvelope envelopes = 1;
+      // The catch-up wave that produced this frame: the Mutate's mutate_id
+      // for wave replay, 0 for live tail.
+      uint64 mutate_id = 2;
     }
 
     // The first frame on every stream.
@@ -157,20 +170,25 @@ message SubscribeResponse {
       repeated Capability capabilities = 2;
     }
 
-    // Sent once per Mutate that adds subscriptions (a catch-up "wave"), after
-    // the wave's last TopicsLive: everything the Mutate asked for is delivered.
+    // Sent once per Mutate: at wave completion (after the wave's last
+    // TopicsLive) for a Mutate that started a catch-up "wave", immediately for
+    // one that did not (nothing added — removes-only or empty — or every add
+    // a no-op). Also the catch-up
+    // seam: live frames (mutate_id 0) for the wave's topics begin only after
+    // this frame.
     message CatchupComplete {
-      uint64 mutate_id = 1; // echoes the Mutate that started this wave (0 if none given)
+      uint64 mutate_id = 1; // echoes the Mutate; 0 only if a waveless Mutate carried 0
     }
 
     // Emitted when topics finish catch-up, AFTER the last history frame for
-    // them — including any live envelopes that queued behind the catch-up,
-    // which were equally historical from the client's perspective — so every
-    // later frame for a listed topic is live tail. Informational only: delivery
+    // them — including envelopes that arrived mid-wave and were folded into it,
+    // which were equally historical from the client's perspective — so no
+    // further replay for a listed topic follows; its live (mutate_id 0) frames
+    // begin after the wave's CatchupComplete. Informational only: delivery
     // correctness (no duplicates, no gaps) never depends on it. Re-adding a
     // topic re-runs catch-up and re-emits it; receivers treat it idempotently.
     message TopicsLive {
-      repeated bytes topics = 1; // kind-prefixed topics now tailing live
+      repeated bytes topics = 1; // kind-prefixed topics done replaying
     }
 
     // Optional per-stream protocol features (none defined yet; future revisions


### PR DESCRIPTION
Adds the XIP-83 server-side delivery tag to both `Subscribe` bindings, per the revised spec (xmtp/XIPs#139):

- `mls.api.v1 SubscribeResponse.V1.Messages.mutate_id = 3` and `xmtpv4.message_api SubscribeResponse.V1.Envelopes.mutate_id = 2`: every delivery frame carries the catch-up wave that produced it (the originating `Mutate`'s `mutate_id`); `0` means live tail. A frame never mixes lanes or waves.
- `Mutate.mutate_id` is required nonzero when `adds` are present (the server fails the stream with `INVALID_ARGUMENT` otherwise) and SHOULD be unique per stream.
- Comment updates pinning the rest of the revised contract: per-lane ordering (per message kind on v3, per originator on d14n), the catch-up seam (live frames for a wave's topics begin only after its `CatchupComplete`), `CatchupComplete` acking every `Mutate` (immediately when no wave starts), `history_only` meaning "everything as of the wave's start", and removes clearing the topic's cursor floor.

Wire-compatible: `buf breaking` against `main` is clean (additive fields + comment changes only).

Landing order: this PR lands first; the xmtp-node-go and xmtpd implementation PRs vendor code generated from these protos and follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `mutate_id` field to Subscribe delivery frames for catch-up wave tracking
> - Adds `mutate_id` (uint64) to `SubscribeResponse.V1.Messages` in [mls.proto](https://github.com/xmtp/proto/pull/340/files#diff-ecc5f7ce37e02e9997785d5b1a63c97a03b96d475ba95a22a39866591a22b051) and `SubscribeResponse.V1.Envelopes` in [message_api.proto](https://github.com/xmtp/proto/pull/340/files#diff-72b1e00eb3b484952fa9e85e171a9ede388143ea0ff46a73314ceadc80ee17f0); nonzero values identify catch-up replay frames belonging to a specific wave, while 0 indicates live tail frames.
> - Updates `CatchupComplete` comments to clarify it serves as the seam after which live (mutate_id 0) frames begin for the wave's topics.
> - Expands `mutate_id` validation rules on `SubscribeRequest.V1.Mutate`: must be nonzero when adds are present and must not collide with an in-flight wave; violations fail the stream with `INVALID_ARGUMENT`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized da6dcf1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->